### PR TITLE
Fix movement sequence counter byte order

### DIFF
--- a/app/src/main/java/com/ruuvi/station/decoder/DecodeFormat5.java
+++ b/app/src/main/java/com/ruuvi/station/decoder/DecodeFormat5.java
@@ -27,7 +27,7 @@ public class DecodeFormat5 implements RuuviTagDecoder {
             tag.txPower = (powerInfo & 0b11111) * 2 - 40;
         }
         tag.movementCounter = data[15 + offset] & 0xFF;
-        tag.measurementSequenceNumber = (data[17 + offset] & 0xFF) << 8 | data[16 + offset] & 0xFF;
+        tag.measurementSequenceNumber = (data[16 + offset] & 0xFF) << 8 | data[17 + offset] & 0xFF;
 
         // make it pretty
         tag.temperature = round(tag.temperature, 2);


### PR DESCRIPTION
The MovementSequenceCounter is sent as most significant byte first value, this PR fixes byte order.

I've not tested the PR in any way, if there is a test process I should run I'd be happy to go through it.