### PR TITLE
ISSUE #407 Fix displaying wrong unit for Humidity alarm

### DIFF
--- a/app/src/main/java/com/ruuvi/station/alarm/ui/AlarmEditView.kt
+++ b/app/src/main/java/com/ruuvi/station/alarm/ui/AlarmEditView.kt
@@ -47,7 +47,7 @@ class AlarmEditView @JvmOverloads
         with(binding.alertSwitch) {
             text = when (alarm.type) {
                 AlarmType.TEMPERATURE -> ctx.getString(R.string.temperature, unitsConverter.getTemperatureUnitString())
-                AlarmType.HUMIDITY -> ctx.getString(R.string.humidity, unitsConverter.getHumidityUnitString())
+                AlarmType.HUMIDITY -> ctx.getString(R.string.humidity, ctx.getString(R.string.humidity_relative_unit))
                 AlarmType.PRESSURE -> ctx.getString(R.string.pressure, unitsConverter.getPressureUnitString())
                 AlarmType.RSSI -> ctx.getString(R.string.rssi)
                 AlarmType.MOVEMENT -> ctx.getString(R.string.alert_movement)


### PR DESCRIPTION
[FIXED] always showing % for relative humidity