### PR TITLE
ISSUE #444 Unification: show/hide SYNC button in charts

### DIFF
--- a/app/src/main/java/com/ruuvi/station/database/domain/TagRepository.kt
+++ b/app/src/main/java/com/ruuvi/station/database/domain/TagRepository.kt
@@ -41,6 +41,7 @@ class TagRepository(
                 val previousUpdate = tagEntry.updateAt
                 if (previousUpdate == null ||  previousUpdate < reading.createdAt) {
                     tagEntry.updateData(reading)
+                    tagEntry.connectable = false
                 }
                 tagEntry.update()
             }


### PR DESCRIPTION
[CHANGED] if last measurement came from cloud - hide sync/clear buttons