### PR TITLE
ISSUE #575 Hide charts for missing sensors (pressure for example)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -80,8 +80,8 @@ dependencies {
     // https://mvnrepository.com/artifact/com.opencsv/opencsv
     implementation 'com.opencsv:opencsv:3.10'
 
-    implementation 'com.github.ruuvi:com.ruuvi.bluetooth:1.4.2'
-    implementation 'com.github.ruuvi:com.ruuvi.bluetooth.default:1.4.7'
+    implementation 'com.github.ruuvi:com.ruuvi.bluetooth:1.4.3'
+    implementation 'com.github.ruuvi:com.ruuvi.bluetooth.default:1.4.8'
 //    implementation project(':bluetooth_library')
 //    implementation project(':default_bluetooth_library')
     implementation 'no.nordicsemi.android:dfu:1.12.0'

--- a/app/src/main/java/com/ruuvi/station/tagsettings/domain/CsvExporter.kt
+++ b/app/src/main/java/com/ruuvi/station/tagsettings/domain/CsvExporter.kt
@@ -76,9 +76,9 @@ class CsvExporter(
                 fileWriter.append(',')
                 fileWriter.append(unitsConverter.getTemperatureValue(reading.temperature).toString())
                 fileWriter.append(',')
-                fileWriter.append(reading.humidity?.let { unitsConverter.getHumidityValue(it, reading.temperature).toString() })
+                fileWriter.append(reading.humidity?.let { unitsConverter.getHumidityValue(it, reading.temperature).toString() } ?: nullValue)
                 fileWriter.append(',')
-                fileWriter.append(reading.pressure?.let { unitsConverter.getPressureValue(it).toString() })
+                fileWriter.append(reading.pressure?.let { unitsConverter.getPressureValue(it).toString() } ?: nullValue)
                 fileWriter.append(',')
                 fileWriter.append(reading.rssi.toString())
                 if (tag?.dataFormat == 3 || tag?.dataFormat == 5) {
@@ -119,5 +119,9 @@ class CsvExporter(
         sendIntent.type = "text/csv"
         sendIntent.flags = Intent.FLAG_GRANT_READ_URI_PERMISSION
         context.startActivity(Intent.createChooser(sendIntent, context.getString(R.string.export_csv_chooser_title, tag?.id)))
+    }
+
+    companion object {
+        private const val nullValue = "-"
     }
 }


### PR DESCRIPTION
[ADDED] Support for nullable pressure and humidity for GATT sync
[CHANGED] show null values in csv as "-"