### PR TITLE
Use bash for localization script

### DIFF
--- a/scripts/ci/update_l10n.sh
+++ b/scripts/ci/update_l10n.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # This script is used to update the l10n files in the repository.
 # It is meant to be run by the CI system.


### PR DESCRIPTION
Motivation: enable on ubuntu and macOS

The line `#!/bin/sh` at the beginning of a script is known as a "shebang" or "hashbang". This line tells the system what interpreter to use to execute the script. Here's a breakdown of its components:

1. `#!`: This is the shebang itself. It's a special two-character sequence that is detected by the Unix and Linux operating systems when it appears at the start of a script. It indicates that the script should be passed to an interpreter.

2. `/bin/sh`: This specifies the interpreter that should be used to run the script. In this case, `/bin/sh` points to the shell interpreter, which is a command-line interpreter that executes commands read from a command-line string, the standard input, or a specified file.

The purpose of the shebang is to ensure that the script is executed using the correct interpreter, no matter what the default shell or environment settings of the user might be. When you run the script, the system reads the shebang to determine which interpreter to launch, and then passes the script to that interpreter.

It's important to note that `/bin/sh` is typically linked to a POSIX-compliant shell on most Unix-like systems. On many Linux distributions, `/bin/sh` is often linked to `bash` (Bourne Again SHell) or another compatible shell, but with behavior restricted to POSIX compliance for compatibility. On macOS, `/bin/sh` is also a POSIX-compliant shell, but in older versions of macOS, it's linked to an older version of `bash`, and in newer versions, it might be linked to `zsh` or another shell.

Therefore, if you're writing a script with `#!/bin/sh`, you should ensure that it adheres to POSIX shell syntax and features for maximum compatibility across different systems.