### PR TITLE
Remove Buy sensors links from app UI

### DIFF
--- a/app/src/main/java/com/ruuvi/station/addtag/ui/AddTagActivity.kt
+++ b/app/src/main/java/com/ruuvi/station/addtag/ui/AddTagActivity.kt
@@ -25,7 +25,6 @@ import com.ruuvi.station.databinding.ActivityAddTagBinding
 import com.ruuvi.station.nfc.NfcScanReciever
 import com.ruuvi.station.tagdetails.ui.SensorCardActivity
 import com.ruuvi.station.util.base.NfcActivity
-import com.ruuvi.station.util.extensions.openUrl
 import org.kodein.di.Kodein
 import org.kodein.di.KodeinAware
 import org.kodein.di.android.closestKodein
@@ -92,7 +91,6 @@ class AddTagActivity : NfcActivity(R.layout.activity_add_tag), KodeinAware {
                 tags.clear()
                 tags.addAll(ruuviTags)
                 binding.content.noSensorsLayout.isVisible = tags.isEmpty()
-                binding.content.buySensorsButton2.isVisible = tags.isNotEmpty()
                 adapter.notifyDataSetChanged()
             }
         }
@@ -130,14 +128,6 @@ class AddTagActivity : NfcActivity(R.layout.activity_add_tag), KodeinAware {
             }
             viewModel.makeSensorFavorite(tag)
             TagSettingsActivity.startAfterAddingNewSensor(this, tag.id)
-        }
-
-        binding.content.buySensorsButton.setOnClickListener {
-            openUrl(getString(R.string.buy_sensors_link))
-        }
-
-        binding.content.buySensorsButton2.setOnClickListener {
-            openUrl(getString(R.string.buy_sensors_link))
         }
 
         binding.content.nfcHintTextView.isVisible = viewModel.nfcSupported

--- a/app/src/main/java/com/ruuvi/station/app/ui/MainMenu.kt
+++ b/app/src/main/java/com/ruuvi/station/app/ui/MainMenu.kt
@@ -93,10 +93,6 @@ fun DashboardMainMenu(
                 R.string.menu_what_to_measure,
                 stringResource(id = R.string.menu_what_to_measure)
             ),
-            MenuItem(
-                R.string.menu_buy_sensors,
-                stringResource(id = R.string.menu_buy_sensors)
-            ),
             if (signedIn) {
                 MenuItem(
                     R.string.my_ruuvi_account,
@@ -116,7 +112,6 @@ fun DashboardMainMenu(
                 R.string.menu_about_help -> AboutActivity.start(context)
                 R.string.menu_send_feedback -> context.sendFeedback()
                 R.string.menu_what_to_measure -> context.openUrl(context.getString(R.string.what_to_measure_link))
-                R.string.menu_buy_sensors -> context.openUrl(context.getString(R.string.buy_sensors_menu_link))
                 R.string.my_ruuvi_account -> MyAccountActivity.start(context)
                 R.string.sign_in -> SignInActivity.start(context)
             }

--- a/app/src/main/res/layout/content_add_tag.xml
+++ b/app/src/main/res/layout/content_add_tag.xml
@@ -75,26 +75,6 @@
         android:layout_height="wrap_content"
         style="@style/Title"/>
 
-        <Button
-            android:id="@+id/buySensorsButton"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/menu_buy_sensors"
-            android:layout_marginTop="@dimen/button_bottom_padding"
-            android:layout_gravity="center"
-            style="@style/RoundButton" />
-
     </LinearLayout>
-
-    <Button
-        android:id="@+id/buySensorsButton2"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="@string/menu_buy_sensors"
-        android:layout_marginBottom="@dimen/button_bottom_padding"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        style="@style/RoundButton" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/menu/menu_main.xml
+++ b/app/src/main/res/menu/menu_main.xml
@@ -39,13 +39,6 @@
                 android:title="@string/menu_what_to_measure" />
         </group>
         <group
-            android:id="@+id/getMoreSensorsGroup"
-            android:checkableBehavior="none">
-            <item
-                android:id="@+id/getMoreSensorsMenuItem"
-                android:title="@string/menu_buy_sensors" />
-        </group>
-        <group
             android:id="@+id/getGatewayGroup"
             android:checkableBehavior="none">
             <item


### PR DESCRIPTION
closes #1532

## Summary
- remove "Buy Ruuvi sensors" item from the main drawer menu (Compose and legacy XML menu)
- remove "Buy Ruuvi Sensors" buttons from Add Sensor screen
- remove click handlers that opened buy-sensors URLs

## Review notes
- localization string files are generated via `scripts/ci/update_l10n.sh`, so this PR intentionally avoids manual string-key deletions
- verified compile/resources with:
  - `./gradlew :app:compileWithoutFileLogsDebugKotlin :app:mergeWithoutFileLogsDebugResources`
- no behavior changes beyond removing the buy-sensors entry points
