### PR TITLE
Rewrite ReleaseTree class #1548

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -80,7 +80,7 @@ android {
         }
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
 
@@ -130,7 +130,7 @@ android {
 dependencies {
     implementation project(":MPChartLib")
     implementation fileTree(include: ['*.jar'], dir: 'libs')
-    implementation files('..\\Xlsx\\xlsx-writer.jar')
+    implementation files('../Xlsx/xlsx-writer.jar')
     androidTestImplementation('androidx.test.espresso:espresso-core:3.1.0', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })

--- a/app/src/main/java/com/ruuvi/station/app/RuuviScannerApplication.kt
+++ b/app/src/main/java/com/ruuvi/station/app/RuuviScannerApplication.kt
@@ -22,6 +22,7 @@ import com.ruuvi.station.network.domain.RuuviNetworkInteractor
 import com.ruuvi.station.util.Foreground
 import com.ruuvi.station.util.ForegroundListener
 import com.ruuvi.station.util.ReleaseTree
+import com.ruuvi.station.util.extensions.registerReceiverCompat
 import org.kodein.di.Kodein
 import org.kodein.di.KodeinAware
 import org.kodein.di.conf.ConfigurableKodein
@@ -81,7 +82,7 @@ class RuuviScannerApplication : Application(), KodeinAware {
         version3MigrationInteractor.migrate()
         visibleMeasurementsMigrationInteractor.migrate()
 
-        registerReceiver(bluetoothReceiver, IntentFilter(BluetoothAdapter.ACTION_STATE_CHANGED))
+        registerReceiverCompat(bluetoothReceiver, IntentFilter(BluetoothAdapter.ACTION_STATE_CHANGED))
 
         defaultOnTagFoundListener.isForeground = isInForeground
         foreground.addListener(listener)

--- a/app/src/main/java/com/ruuvi/station/bluetooth/domain/BluetoothDevicesInteractor.kt
+++ b/app/src/main/java/com/ruuvi/station/bluetooth/domain/BluetoothDevicesInteractor.kt
@@ -7,6 +7,7 @@ import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
 import com.ruuvi.station.bluetooth.model.DeviceInfo
+import com.ruuvi.station.util.extensions.registerReceiverCompat
 import timber.log.Timber
 
 class BluetoothDevicesInteractor(
@@ -34,7 +35,7 @@ class BluetoothDevicesInteractor(
     }
 
     init {
-        context.registerReceiver(receiver, IntentFilter(BluetoothDevice.ACTION_FOUND))
+        context.registerReceiverCompat(receiver, IntentFilter(BluetoothDevice.ACTION_FOUND))
     }
 
     fun discoverDevices(discoveredCallback: (DeviceInfo) -> Unit) {

--- a/app/src/main/java/com/ruuvi/station/dashboard/domain/SensorsSortingInteractor.kt
+++ b/app/src/main/java/com/ruuvi/station/dashboard/domain/SensorsSortingInteractor.kt
@@ -14,12 +14,6 @@ class SensorsSortingInteractor (
     fun sortSensors(sensors: List<RuuviTag>): List<RuuviTag> {
         val sortingOrder = getListOfSortedSensors()
 
-        for (sens in sortingOrder) {
-            Timber.d("sortedResult $sens")
-        }
-        Timber.d("sortedResult =========================")
-
-
         if (sortingOrder.isEmpty()) return sensors
 
         val originalList = sensors.toMutableList()
@@ -39,10 +33,6 @@ class SensorsSortingInteractor (
 
     fun newOrder(sensorIds: List<String>) {
         saveListOfSortedSensors(sensorIds)
-        for (sens in sensorIds) {
-            Timber.d("dragGestureHandler - newOrder $sens")
-        }
-        Timber.d("dragGestureHandler - newOrder =========================")
     }
 
     fun getListOfSortedSensors(): List<String> {

--- a/app/src/main/java/com/ruuvi/station/image/ImageInteractor.kt
+++ b/app/src/main/java/com/ruuvi/station/image/ImageInteractor.kt
@@ -52,7 +52,11 @@ class ImageInteractor (
     )
 
     private fun getExternalFilesDir() =
-        context.getExternalFilesDir(Environment.DIRECTORY_PICTURES)
+        requireNotNull(
+            context.getExternalFilesDir(Environment.DIRECTORY_PICTURES)
+        ) {
+            "External files directory unavailable"
+        }
 
     suspend fun downloadImage(filename: String, url: String): File {
         return suspendCoroutine { continuation ->

--- a/app/src/main/java/com/ruuvi/station/network/ui/ShareSensorActivity.kt
+++ b/app/src/main/java/com/ruuvi/station/network/ui/ShareSensorActivity.kt
@@ -313,7 +313,6 @@ fun SharingWebView(
                         settings.allowContentAccess = true
                         settings.allowFileAccess = true
                         settings.domStorageEnabled = true
-                        settings.databaseEnabled = true
                         settings.cacheMode = LOAD_DEFAULT
                         setWebViewClient(object: WebViewClient() {
                             override fun shouldOverrideUrlLoading(

--- a/app/src/main/java/com/ruuvi/station/util/ReleaseTree.java
+++ b/app/src/main/java/com/ruuvi/station/util/ReleaseTree.java
@@ -15,15 +15,19 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.Locale;
 import java.util.TimeZone;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 import io.reactivex.Completable;
 import io.reactivex.schedulers.Schedulers;
 import timber.log.Timber;
 
+@SuppressLint("LogNotTimber")
 public class ReleaseTree extends Timber.Tree {
 
     private final SimpleDateFormat timeFormat = new SimpleDateFormat("HH:mm:ss", Locale.UK);
+    private final ExecutorService logExecutor = Executors.newSingleThreadExecutor();
 
     public ReleaseTree() {
         timeFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
@@ -32,7 +36,7 @@ public class ReleaseTree extends Timber.Tree {
 
     @Override
     protected void log(int priority, @Nullable String tag, @NotNull String message, @Nullable Throwable throwable) {
-        writeLogToFile(tag, message, throwable);
+        logExecutor.execute(() -> writeLogToFile(tag, message, throwable));
     }
 
     @SuppressLint("CheckResult")
@@ -58,7 +62,7 @@ public class ReleaseTree extends Timber.Tree {
                 .subscribe(
                         () -> {
                         },
-                        Throwable::printStackTrace
+                        throwable -> android.util.Log.e("ReleaseTree", "deleteOldLogs failed", throwable)
                 );
     }
 
@@ -69,18 +73,17 @@ public class ReleaseTree extends Timber.Tree {
     }
 
     private void writeLogToFile(String tag, String message, Throwable throwable) {
-
         String fileName = getFileName();
         File filePath = getDirectoryPath();
         File file = new File(filePath, fileName);
-        try {
 
-            PrintWriter printWriter = new PrintWriter(new OutputStreamWriter(new FileOutputStream(file, true)));
+        if (!filePath.exists() && !filePath.mkdirs()) {
+            android.util.Log.e("ReleaseTree", "Failed to create directory: " + filePath);
+            return;
+        }
 
-            String tagString = "";
-            if (tag != null) {
-                tagString = " " + tag + " :";
-            }
+        try (PrintWriter printWriter = new PrintWriter(new OutputStreamWriter(new FileOutputStream(file, true)))) {
+            String tagString = (tag != null) ? " " + tag + " :" : "";
             printWriter.write("[" + getCurrentTimeString() + "]" + tagString + " " + message);
             if (throwable != null) {
                 throwable.printStackTrace(printWriter);
@@ -88,10 +91,8 @@ public class ReleaseTree extends Timber.Tree {
             printWriter.println();
             printWriter.println();
 
-            printWriter.close();
         } catch (Throwable e) {
-            e.printStackTrace();
-            e.printStackTrace();
+            android.util.Log.e("ReleaseTree", "Failed to write log to file", e);
         }
     }
 
@@ -128,7 +129,7 @@ public class ReleaseTree extends Timber.Tree {
 
             return calendar;
         } catch (Throwable throwable) {
-            throwable.printStackTrace();
+            android.util.Log.e("ReleaseTree", "getDateFromFileName failed for: " + fileName, throwable);
         }
         return null;
     }

--- a/app/src/main/java/com/ruuvi/station/util/extensions/BroadcastReceiverExtensions.kt
+++ b/app/src/main/java/com/ruuvi/station/util/extensions/BroadcastReceiverExtensions.kt
@@ -1,0 +1,27 @@
+package com.ruuvi.station.util.extensions
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.IntentFilter
+import android.os.Build
+
+fun Context.registerReceiverCompat(
+    receiver: BroadcastReceiver,
+    filter: IntentFilter,
+    exported: Boolean = false
+) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        registerReceiver(
+            receiver,
+            filter,
+            if (exported) {
+                Context.RECEIVER_EXPORTED
+            } else {
+                Context.RECEIVER_NOT_EXPORTED
+            }
+        )
+    } else {
+        @Suppress("UnspecifiedRegisterReceiverFlag")
+        registerReceiver(receiver, filter)
+    }
+}

--- a/app/src/main/java/com/ruuvi/station/widgets/ui/complexWidget/ComplexWidgetConfigureActivity.kt
+++ b/app/src/main/java/com/ruuvi/station/widgets/ui/complexWidget/ComplexWidgetConfigureActivity.kt
@@ -92,7 +92,9 @@ class ComplexWidgetConfigureActivity : AppCompatActivity(), KodeinAware {
         val updateIntent = Intent(this, ComplexWidgetProvider::class.java).apply {
             action = ACTION_APPWIDGET_UPDATE
             putExtra(AppWidgetManager.EXTRA_APPWIDGET_IDS, intArrayOf(appWidgetId))
+            `package` = packageName
         }
+
         sendBroadcast(updateIntent)
 
         val resultValue =


### PR DESCRIPTION
- Logs writing to local storage was previous done into main thread and blocking the UI
- Now put the logs writing to local storage moved to a background thread
- Two unecessary Timber.log removed
- Two deprecation change in build.gradle

Try to run the app with build variant withFileLogsDebug or withoutFileLogsDebug. Previously the whole UI was sluggish, now sluggishness is less but after few minutes UI get back to normal.