### PR TITLE
Disable Cloud alert from notification #1546

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,27 @@ We would love you for the contribution to **Ruuvi Station**, check the ``LICENSE
 6. Sync project with Gradle file
 7. Now you can run project on emulator or phone
 
+### Push Notifications Setup (Firebase)
+To receive Cloud Push Notifications during development, you must register your local debug SHA-1 fingerprint:
+
+1. **Get your SHA-1 Fingerprint:**
+   - Run `./gradlew signingReport` in the Android Studio terminal.
+   - Copy the SHA1 string from the `debug` variant.
+
+2. **Firebase Console:**
+   - Go to [Firebase Console](https://console.firebase.google.com/) -> Project Settings.
+   - Add your SHA-1 fingerprint to the Android app.
+   - Download the updated `google-services.json` and replace the one in your `/app/` folder.
+
+3. **Google Cloud Console:**
+   - Go to [Google Cloud Credentials](https://console.cloud.google.com/apis/credentials).
+   - Find the **Android key (auto created by Firebase)**.
+   - Ensure the **Firebase Installations API** is added to the list of allowed APIs for this key.
+   - Verify that the **Firebase Installations API** is enabled in the [API Library](https://console.cloud.google.com/apis/library).
+
+4. **Finalize:**
+   - Clean and Rebuild the project in Android Studio.
+
 Watch video showing build process:
 
 <a href="https://www.youtube.com/watch?v=1sXIASGXaaw"><img src="/docs/playvideo.png?raw=true" alt="Watch video" height="400"/></a>

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ We would love you for the contribution to **Ruuvi Station**, check the ``LICENSE
 7. Now you can run project on emulator or phone
 
 ### Push Notifications Setup (Firebase)
+
 To receive Cloud Push Notifications during development, you must register your local debug SHA-1 fingerprint:
 
 1. **Get your SHA-1 Fingerprint:**

--- a/app/src/main/java/com/ruuvi/station/alarm/domain/AlarmCheckInteractor.kt
+++ b/app/src/main/java/com/ruuvi/station/alarm/domain/AlarmCheckInteractor.kt
@@ -77,13 +77,12 @@ class AlarmCheckInteractor(
         alarmRepository.getForSensor(ruuviTag.id).filter { it.enabled }
 
     private fun canNotify(alarm: Alarm): Boolean {
-        val pushNotificationsDisabled = preferencesRepository.isDisablePushNotifications()
         val dosingAlert = alarm.latestTriggered?.diffGreaterThan(NOTIFICATION_THRESHOLD_DOSING) == false
         val limitLocalAlerts = preferencesRepository.getLimitLocalAlerts() &&
                 alarm.latestTriggered?.diffGreaterThan(LIMIT_LOCAL_ALERTS_THRESHOLD) == false
         val mutedAlarm = alarm.mutedTill?.let { it > Date()} ?: false
 
-        return !(mutedAlarm || limitLocalAlerts || dosingAlert || pushNotificationsDisabled)
+        return !(mutedAlarm || limitLocalAlerts || dosingAlert)
     }
 
     private fun sendAlert(checker: AlarmChecker) {

--- a/app/src/main/java/com/ruuvi/station/alarm/domain/AlarmCheckInteractor.kt
+++ b/app/src/main/java/com/ruuvi/station/alarm/domain/AlarmCheckInteractor.kt
@@ -77,13 +77,13 @@ class AlarmCheckInteractor(
         alarmRepository.getForSensor(ruuviTag.id).filter { it.enabled }
 
     private fun canNotify(alarm: Alarm): Boolean {
+        val pushNotificationsDisabled = preferencesRepository.isDisablePushNotifications()
         val dosingAlert = alarm.latestTriggered?.diffGreaterThan(NOTIFICATION_THRESHOLD_DOSING) == false
         val limitLocalAlerts = preferencesRepository.getLimitLocalAlerts() &&
                 alarm.latestTriggered?.diffGreaterThan(LIMIT_LOCAL_ALERTS_THRESHOLD) == false
         val mutedAlarm = alarm.mutedTill?.let { it > Date()} ?: false
 
-        Timber.d("canNotify mutedAlarm = $mutedAlarm limitLocalAlerts = $limitLocalAlerts dosingAlert = $dosingAlert ${alarm.latestTriggered}")
-        return !(mutedAlarm || limitLocalAlerts || dosingAlert)
+        return !(mutedAlarm || limitLocalAlerts || dosingAlert || pushNotificationsDisabled)
     }
 
     private fun sendAlert(checker: AlarmChecker) {

--- a/app/src/main/java/com/ruuvi/station/alarm/domain/AlarmsInteractor.kt
+++ b/app/src/main/java/com/ruuvi/station/alarm/domain/AlarmsInteractor.kt
@@ -263,6 +263,6 @@ class AlarmsInteractor(
             mutedTill = state.mutedTill,
             timestamp = null
         )
-        return networkInteractor.setAlert(alarm)
+        return networkInteractor.setAlertWithStatus(alarm)
     }
 }

--- a/app/src/main/java/com/ruuvi/station/alarm/receiver/CancelAlarmReceiver.kt
+++ b/app/src/main/java/com/ruuvi/station/alarm/receiver/CancelAlarmReceiver.kt
@@ -7,6 +7,9 @@ import android.content.Intent
 import com.ruuvi.station.alarm.domain.AlarmCheckInteractor
 import com.ruuvi.station.database.domain.AlarmRepository
 import com.ruuvi.station.network.domain.RuuviNetworkInteractor
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import org.kodein.di.Kodein
 import org.kodein.di.KodeinAware
 import org.kodein.di.generic.instance
@@ -18,21 +21,29 @@ class CancelAlarmReceiver : BroadcastReceiver(), KodeinAware {
     private val networkInteractor: RuuviNetworkInteractor by instance()
 
     override fun onReceive(context: Context, intent: Intent) {
+        val pendingResult = goAsync()
         kodein = (context.applicationContext as KodeinAware).kodein
         val alarmCheckInteractor: AlarmCheckInteractor by kodein.instance()
 
         val alarmId = intent.getIntExtra("alarmId", DEFAULT_ID)
         val notificationId = intent.getIntExtra("notificationId", DEFAULT_ID)
-        if (alarmId != -1) {
-            val alarm = alarmRepository.getById(alarmId)
-            if (alarm != null) {
-                alarmRepository.disableAlarm(alarm)
-                if (networkInteractor.signedIn) {
-                    networkInteractor.setAlert(alarm)
+
+        CoroutineScope(Dispatchers.IO).launch {
+            try {
+                if (alarmId != DEFAULT_ID) {
+                    val alarm = alarmRepository.getById(alarmId)
+                    if (alarm != null) {
+                        alarmRepository.disableAlarm(alarm)
+                        if (networkInteractor.signedIn) {
+                            networkInteractor.setAlert(alarm)?.join()
+                        }
+                    }
                 }
+                alarmCheckInteractor.removeNotificationById(notificationId)
+            } finally {
+                pendingResult.finish()
             }
         }
-        alarmCheckInteractor.removeNotificationById(notificationId)
     }
 
     companion object {

--- a/app/src/main/java/com/ruuvi/station/app/domain/migration/VisibleMeasurementsMigrationInteractor.kt
+++ b/app/src/main/java/com/ruuvi/station/app/domain/migration/VisibleMeasurementsMigrationInteractor.kt
@@ -62,8 +62,7 @@ class VisibleMeasurementsMigrationInteractor(
                     AlarmType.PM10.value, AlarmType.PM40.value, AlarmType.PM100.value -> {
                         if (ruuviTag?.defaultDisplayOrder == true) {
                             alarmRepository.disableAlarm(alarm)
-                            val flow = networkInteractor.setAlertWithStatus(alarm)
-                            flow?.launchIn(CoroutineScope(Dispatchers.IO))
+                            networkInteractor.setAlert(alarm)
                         }
                     }
                 }

--- a/app/src/main/java/com/ruuvi/station/app/domain/migration/VisibleMeasurementsMigrationInteractor.kt
+++ b/app/src/main/java/com/ruuvi/station/app/domain/migration/VisibleMeasurementsMigrationInteractor.kt
@@ -62,7 +62,7 @@ class VisibleMeasurementsMigrationInteractor(
                     AlarmType.PM10.value, AlarmType.PM40.value, AlarmType.PM100.value -> {
                         if (ruuviTag?.defaultDisplayOrder == true) {
                             alarmRepository.disableAlarm(alarm)
-                            val flow = networkInteractor.setAlert(alarm)
+                            val flow = networkInteractor.setAlertWithStatus(alarm)
                             flow?.launchIn(CoroutineScope(Dispatchers.IO))
                         }
                     }

--- a/app/src/main/java/com/ruuvi/station/database/domain/AlarmRepository.kt
+++ b/app/src/main/java/com/ruuvi/station/database/domain/AlarmRepository.kt
@@ -55,6 +55,7 @@ class AlarmRepository {
 
     fun disableAlarm(alarm: Alarm) {
         alarm.enabled = false
+        alarm.lastUpdated = Date().time / 1000
         alarm.update()
     }
 

--- a/app/src/main/java/com/ruuvi/station/network/data/request/SetAlertRequest.kt
+++ b/app/src/main/java/com/ruuvi/station/network/data/request/SetAlertRequest.kt
@@ -16,7 +16,7 @@ data class SetAlertRequest(
         fun getAlarmRequest(alarm: Alarm): SetAlertRequest {
             return SetAlertRequest(
                 sensor = alarm.ruuviTagId,
-                type = alarm.alarmType?.networkCode ?: throw IllegalArgumentException(),
+                type = alarm.alarmType.networkCode ?: throw IllegalArgumentException(),
                 min = alarm.min,
                 max = alarm.max,
                 enabled = alarm.enabled,

--- a/app/src/main/java/com/ruuvi/station/network/domain/NetworkRequestExecutor.kt
+++ b/app/src/main/java/com/ruuvi/station/network/domain/NetworkRequestExecutor.kt
@@ -26,14 +26,11 @@ class NetworkRequestExecutor (
 ){
     private fun getToken() = tokenRepository.getTokenInfo()
 
-    fun registerRequest(networkRequest: NetworkRequest, executeNow: Boolean = true) {
-        Timber.d("registerRequest $networkRequest $executeNow")
-        CoroutineScope(Dispatchers.IO).launch {
+    fun registerRequest(networkRequest: NetworkRequest, executeNow: Boolean = true): Job {
+        return CoroutineScope(Dispatchers.IO).launch {
             disableSimilarRequest (networkRequest)
             networkRequestRepository.saveRequest(networkRequest)
-            Timber.d("request saved $networkRequest")
             if (executeNow) {
-                Timber.d("execute NOW $networkRequest")
                 delay(1000)
                 val request = networkRequestRepository.getById(networkRequest.id)
                 if (request != null && request.status == NetworkRequestStatus.READY) {

--- a/app/src/main/java/com/ruuvi/station/network/domain/RuuviNetworkInteractor.kt
+++ b/app/src/main/java/com/ruuvi/station/network/domain/RuuviNetworkInteractor.kt
@@ -271,29 +271,26 @@ class RuuviNetworkInteractor (
     }
 
     fun setAlert(alarm: Alarm) {
-        if (shouldSendSensorDataToNetwork(alarm.ruuviTagId) && alarm.alarmType.networkCode != null) {
-            val networkRequest = NetworkRequest(
-                NetworkRequestType.SET_ALERT,
-                alarm.ruuviTagId + alarm.alarmType.networkCode,
-                SetAlertRequest.getAlarmRequest(alarm)
-            )
-            Timber.d("setAlert $networkRequest")
+        getSetAlertRequest(alarm)?.let { networkRequest ->
             networkRequestExecutor.registerRequest(networkRequest)
         }
     }
 
     fun setAlertWithStatus(alarm: Alarm): Flow<OperationStatus>? {
+        return getSetAlertRequest(alarm)?.let { networkRequest ->
+            return networkRequestExecutor.registerRequestWithStatus(networkRequest)
+        }
+    }
+
+    private fun getSetAlertRequest(alarm: Alarm): NetworkRequest? {
         if (shouldSendSensorDataToNetwork(alarm.ruuviTagId) && alarm.alarmType.networkCode != null) {
-            val networkRequest = NetworkRequest(
+            return NetworkRequest(
                 NetworkRequestType.SET_ALERT,
                 alarm.ruuviTagId + alarm.alarmType.networkCode,
                 SetAlertRequest.getAlarmRequest(alarm)
             )
-            Timber.d("setAlertWithStatus $networkRequest")
-            return networkRequestExecutor.registerRequestWithStatus(networkRequest)
-        } else {
-            return null
         }
+        return null
     }
 
     fun requestDeleteAccount(onResult: (DeleteAccountResponse?) -> Unit) {

--- a/app/src/main/java/com/ruuvi/station/network/domain/RuuviNetworkInteractor.kt
+++ b/app/src/main/java/com/ruuvi/station/network/domain/RuuviNetworkInteractor.kt
@@ -270,8 +270,8 @@ class RuuviNetworkInteractor (
         networkRequestExecutor.registerRequest(networkRequest, true)
     }
 
-    fun setAlert(alarm: Alarm) {
-        getSetAlertRequest(alarm)?.let { networkRequest ->
+    fun setAlert(alarm: Alarm): Job? {
+        return getSetAlertRequest(alarm)?.let { networkRequest ->
             networkRequestExecutor.registerRequest(networkRequest)
         }
     }

--- a/app/src/main/java/com/ruuvi/station/network/domain/RuuviNetworkInteractor.kt
+++ b/app/src/main/java/com/ruuvi/station/network/domain/RuuviNetworkInteractor.kt
@@ -270,14 +270,26 @@ class RuuviNetworkInteractor (
         networkRequestExecutor.registerRequest(networkRequest, true)
     }
 
-    fun setAlert(alarm: Alarm): Flow<OperationStatus>? {
-        if (shouldSendSensorDataToNetwork(alarm.ruuviTagId) && alarm.alarmType?.networkCode != null) {
+    fun setAlert(alarm: Alarm) {
+        if (shouldSendSensorDataToNetwork(alarm.ruuviTagId) && alarm.alarmType.networkCode != null) {
             val networkRequest = NetworkRequest(
                 NetworkRequestType.SET_ALERT,
-                alarm.ruuviTagId + alarm.alarmType?.networkCode,
+                alarm.ruuviTagId + alarm.alarmType.networkCode,
                 SetAlertRequest.getAlarmRequest(alarm)
             )
             Timber.d("setAlert $networkRequest")
+            networkRequestExecutor.registerRequest(networkRequest)
+        }
+    }
+
+    fun setAlertWithStatus(alarm: Alarm): Flow<OperationStatus>? {
+        if (shouldSendSensorDataToNetwork(alarm.ruuviTagId) && alarm.alarmType.networkCode != null) {
+            val networkRequest = NetworkRequest(
+                NetworkRequestType.SET_ALERT,
+                alarm.ruuviTagId + alarm.alarmType.networkCode,
+                SetAlertRequest.getAlarmRequest(alarm)
+            )
+            Timber.d("setAlertWithStatus $networkRequest")
             return networkRequestExecutor.registerRequestWithStatus(networkRequest)
         } else {
             return null


### PR DESCRIPTION
- Updated `AlarmCheckInteractor` to silence local Bluetooth alerts when the global "Push Alerts" setting is disabled.
- Fixed uncollected Flows in `SensorClaimInteractor` and `VisibleMeasurementsMigrationInteractor` to ensure alerts are properly synced during sensor claiming and migrations.
- Updated `README.md` with a detailed "Push Notifications Setup" section to resolve Firebase token retrieval issues (FIS_AUTH_ERROR) during development.