### PR TITLE
Dark theme menu box corners #1360

### DIFF
--- a/app/src/main/java/com/ruuvi/station/app/ui/TopAppBar.kt
+++ b/app/src/main/java/com/ruuvi/station/app/ui/TopAppBar.kt
@@ -131,83 +131,86 @@ fun DashboardTopAppBar(
                     )
                 }
 
-                DropdownMenu(
-                    modifier = Modifier
-                        .background(color = RuuviStationTheme.colors.background)
-                        .padding(all = RuuviStationTheme.dimensions.medium),
-                    expanded = dashboardTypeMenuExpanded,
-                    onDismissRequest = { dashboardTypeMenuExpanded = false }) {
-
-                    Subtitle(
-                        modifier = Modifier.padding(
-                            horizontal = RuuviStationTheme.dimensions.mediumPlus,
-                            vertical = RuuviStationTheme.dimensions.medium
-                        ),
-                        text = stringResource(id = R.string.card_type)
-                    )
-
-                    RadioButtonRuuvi(
-                        text = stringResource(id = R.string.image_cards),
-                        isSelected = dashboardType == DashboardType.IMAGE_VIEW,
-                        onClick = {
-                            changeDashboardType.invoke(DashboardType.IMAGE_VIEW)
-                        }
-                    )
-
-                    RadioButtonRuuvi(
-                        text = stringResource(id = R.string.simple_cards),
-                        isSelected = dashboardType == DashboardType.SIMPLE_VIEW,
-                        onClick = {
-                            changeDashboardType.invoke(DashboardType.SIMPLE_VIEW)
-                        }
-                    )
-
-                    Subtitle(
-                        modifier = Modifier.padding(
-                            horizontal = RuuviStationTheme.dimensions.mediumPlus,
-                            vertical = RuuviStationTheme.dimensions.medium
-                        ),
-                        text = stringResource(id = R.string.card_action)
-                    )
-
-                    RadioButtonRuuvi(
-                        text = stringResource(id = R.string.open_sensor_view),
-                        isSelected = dashboardTapAction == DashboardTapAction.OPEN_CARD,
-                        onClick = {
-                            changeDashboardTapAction.invoke(DashboardTapAction.OPEN_CARD)
-                        }
-                    )
-
-                    RadioButtonRuuvi(
-                        text = stringResource(id = R.string.open_history_view),
-                        isSelected = dashboardTapAction == DashboardTapAction.SHOW_CHART,
-                        onClick = {
-                            changeDashboardTapAction.invoke(DashboardTapAction.SHOW_CHART)
-                        }
-                    )
-
-                    if (isCustomOrderEnabled()) {
-                        Subtitle(
-                            modifier = Modifier.padding(
-                                horizontal = RuuviStationTheme.dimensions.mediumPlus,
-                                vertical = RuuviStationTheme.dimensions.medium
-                            ),
-                            text = stringResource(id = R.string.ordering)
-                        )
-                        
-                        Paragraph(
+                CompositionLocalProvider(LocalElevationOverlay provides null) {
+                    MaterialTheme(colors = MaterialTheme.colors.copy(surface = RuuviStationTheme.colors.background)) {
+                        DropdownMenu(
                             modifier = Modifier
-                                .padding(
+                                .padding(all = RuuviStationTheme.dimensions.medium),
+                            expanded = dashboardTypeMenuExpanded,
+                            onDismissRequest = { dashboardTypeMenuExpanded = false }) {
+
+                            Subtitle(
+                                modifier = Modifier.padding(
                                     horizontal = RuuviStationTheme.dimensions.mediumPlus,
                                     vertical = RuuviStationTheme.dimensions.medium
+                                ),
+                                text = stringResource(id = R.string.card_type)
+                            )
+
+                            RadioButtonRuuvi(
+                                text = stringResource(id = R.string.image_cards),
+                                isSelected = dashboardType == DashboardType.IMAGE_VIEW,
+                                onClick = {
+                                    changeDashboardType.invoke(DashboardType.IMAGE_VIEW)
+                                }
+                            )
+
+                            RadioButtonRuuvi(
+                                text = stringResource(id = R.string.simple_cards),
+                                isSelected = dashboardType == DashboardType.SIMPLE_VIEW,
+                                onClick = {
+                                    changeDashboardType.invoke(DashboardType.SIMPLE_VIEW)
+                                }
+                            )
+
+                            Subtitle(
+                                modifier = Modifier.padding(
+                                    horizontal = RuuviStationTheme.dimensions.mediumPlus,
+                                    vertical = RuuviStationTheme.dimensions.medium
+                                ),
+                                text = stringResource(id = R.string.card_action)
+                            )
+
+                            RadioButtonRuuvi(
+                                text = stringResource(id = R.string.open_sensor_view),
+                                isSelected = dashboardTapAction == DashboardTapAction.OPEN_CARD,
+                                onClick = {
+                                    changeDashboardTapAction.invoke(DashboardTapAction.OPEN_CARD)
+                                }
+                            )
+
+                            RadioButtonRuuvi(
+                                text = stringResource(id = R.string.open_history_view),
+                                isSelected = dashboardTapAction == DashboardTapAction.SHOW_CHART,
+                                onClick = {
+                                    changeDashboardTapAction.invoke(DashboardTapAction.SHOW_CHART)
+                                }
+                            )
+
+                            if (isCustomOrderEnabled()) {
+                                Subtitle(
+                                    modifier = Modifier.padding(
+                                        horizontal = RuuviStationTheme.dimensions.mediumPlus,
+                                        vertical = RuuviStationTheme.dimensions.medium
+                                    ),
+                                    text = stringResource(id = R.string.ordering)
                                 )
-                                .clickableSingle {
-                                    resetSensorsOrderDialog = true
-                                },
-                            text = stringResource(id = R.string.reset_order)
-                        )
+
+                                Paragraph(
+                                    modifier = Modifier
+                                        .padding(
+                                            horizontal = RuuviStationTheme.dimensions.mediumPlus,
+                                            vertical = RuuviStationTheme.dimensions.medium
+                                        )
+                                        .clickableSingle {
+                                            resetSensorsOrderDialog = true
+                                        },
+                                    text = stringResource(id = R.string.reset_order)
+                                )
+                            }
+                        }
                     }
-                }
+                    }
             }
         },
         backgroundColor = RuuviStationTheme.colors.dashboardBackground,

--- a/app/src/main/java/com/ruuvi/station/dashboard/ui/DashboardActivity.kt
+++ b/app/src/main/java/com/ruuvi/station/dashboard/ui/DashboardActivity.kt
@@ -1085,111 +1085,130 @@ fun DashboardItemDropdownMenu(
             )
         }
 
-        DropdownMenu(
-            modifier = Modifier.background(color = RuuviStationTheme.colors.background),
-            expanded = threeDotsMenuExpanded,
-            onDismissRequest = { threeDotsMenuExpanded = false }
-        ) {
-            DropdownMenuItem(onClick = {
-                SensorCardActivity.start(context, sensor.id, SensorCardOpenType.CARD)
-                threeDotsMenuExpanded = false
-            }) {
-                Paragraph(text = stringResource(
-                    id = R.string.full_image_view
-                ))
-            }
-
-            DropdownMenuItem(onClick = {
-                SensorCardActivity.start(context, sensor.id, SensorCardOpenType.HISTORY)
-                threeDotsMenuExpanded = false
-            }) {
-                Paragraph(text = stringResource(
-                    id = R.string.history_view
-                ))
-            }
-            DropdownMenuItem(onClick = {
-                TagSettingsActivity.start(context, sensor.id)
-                threeDotsMenuExpanded = false
-            }) {
-                Paragraph(text = stringResource(
-                    id = R.string.settings_and_alerts
-                ))
-            }
-            DropdownMenuItem(onClick = {
-                BackgroundActivity.start(context, sensor.id)
-                threeDotsMenuExpanded = false
-            }) {
-                Paragraph(text = stringResource(
-                    id = R.string.change_background
-                ))
-            }
-
-            DropdownMenuItem(onClick = {
-                setNameDialog = true
-                threeDotsMenuExpanded = false
-            }) {
-                Paragraph(text = stringResource(
-                    id = R.string.rename
-                ))
-            }
-
-            if (itemIndex != 0) {
-                DropdownMenuItem(onClick = {
-                    var newIndex = itemIndex - 1
-                    moveItem(itemIndex, newIndex, true)
-                    if (newIndex < 0) newIndex = 0
-                    threeDotsMenuExpanded = false
-                    coroutineScope.launch {
-                        lazyGridState.requestScrollToItem(newIndex)
+        CompositionLocalProvider(LocalElevationOverlay provides null) {
+            MaterialTheme(colors = MaterialTheme.colors.copy(surface = RuuviStationTheme.colors.background)) {
+                DropdownMenu(
+                    expanded = threeDotsMenuExpanded,
+                    onDismissRequest = { threeDotsMenuExpanded = false }
+                ) {
+                    DropdownMenuItem(onClick = {
+                        SensorCardActivity.start(context, sensor.id, SensorCardOpenType.CARD)
+                        threeDotsMenuExpanded = false
+                    }) {
+                        Paragraph(
+                            text = stringResource(
+                                id = R.string.full_image_view
+                            )
+                        )
                     }
-                }) {
-                    Paragraph(text = stringResource(id = R.string.move_up))
-                }
-            }
 
-            if (itemIndex != lazyGridState.layoutInfo.totalItemsCount - 2) {
-                DropdownMenuItem(onClick = {
-                    var newIndex = itemIndex + 1
-                    moveItem(itemIndex, newIndex, true)
-                    if (newIndex >= lazyGridState.layoutInfo.totalItemsCount) {
-                        newIndex = lazyGridState.layoutInfo.totalItemsCount - 2
+                    DropdownMenuItem(onClick = {
+                        SensorCardActivity.start(context, sensor.id, SensorCardOpenType.HISTORY)
+                        threeDotsMenuExpanded = false
+                    }) {
+                        Paragraph(
+                            text = stringResource(
+                                id = R.string.history_view
+                            )
+                        )
                     }
-                    threeDotsMenuExpanded = false
-                    coroutineScope.launch {
-                        lazyGridState.requestScrollToItem(newIndex)
+                    DropdownMenuItem(onClick = {
+                        TagSettingsActivity.start(context, sensor.id)
+                        threeDotsMenuExpanded = false
+                    }) {
+                        Paragraph(
+                            text = stringResource(
+                                id = R.string.settings_and_alerts
+                            )
+                        )
                     }
-                }) {
-                    Paragraph(text = stringResource(id = R.string.move_down))
-                }
-            }
+                    DropdownMenuItem(onClick = {
+                        BackgroundActivity.start(context, sensor.id)
+                        threeDotsMenuExpanded = false
+                    }) {
+                        Paragraph(
+                            text = stringResource(
+                                id = R.string.change_background
+                            )
+                        )
+                    }
 
-            if (canBeClaimed) {
-                DropdownMenuItem(onClick = {
-                    ClaimSensorActivity.start(context, sensor.id)
-                    threeDotsMenuExpanded = false
-                }) {
-                    Paragraph(text = stringResource(
-                        id = R.string.claim_sensor
-                    ))
-                }
-            } else if (canBeShared) {
-                DropdownMenuItem(onClick = {
-                    ShareSensorActivity.start(context, sensor.id)
-                    threeDotsMenuExpanded = false
-                }) {
-                    Paragraph(text = stringResource(
-                        id = R.string.share
-                    ))
-                }
-            }
+                    DropdownMenuItem(onClick = {
+                        setNameDialog = true
+                        threeDotsMenuExpanded = false
+                    }) {
+                        Paragraph(
+                            text = stringResource(
+                                id = R.string.rename
+                            )
+                        )
+                    }
 
-            DropdownMenuItem(onClick = {
-                TagSettingsActivity.startToRemove(context, sensor.id)
-                threeDotsMenuExpanded = false
-            }) {
-                Paragraph(text = stringResource(
-                    id = R.string.remove
-                ))
+                    if (itemIndex != 0) {
+                        DropdownMenuItem(onClick = {
+                            var newIndex = itemIndex - 1
+                            moveItem(itemIndex, newIndex, true)
+                            if (newIndex < 0) newIndex = 0
+                            threeDotsMenuExpanded = false
+                            coroutineScope.launch {
+                                lazyGridState.requestScrollToItem(newIndex)
+                            }
+                        }) {
+                            Paragraph(text = stringResource(id = R.string.move_up))
+                        }
+                    }
+
+                    if (itemIndex != lazyGridState.layoutInfo.totalItemsCount - 2) {
+                        DropdownMenuItem(onClick = {
+                            var newIndex = itemIndex + 1
+                            moveItem(itemIndex, newIndex, true)
+                            if (newIndex >= lazyGridState.layoutInfo.totalItemsCount) {
+                                newIndex = lazyGridState.layoutInfo.totalItemsCount - 2
+                            }
+                            threeDotsMenuExpanded = false
+                            coroutineScope.launch {
+                                lazyGridState.requestScrollToItem(newIndex)
+                            }
+                        }) {
+                            Paragraph(text = stringResource(id = R.string.move_down))
+                        }
+                    }
+
+                    if (canBeClaimed) {
+                        DropdownMenuItem(onClick = {
+                            ClaimSensorActivity.start(context, sensor.id)
+                            threeDotsMenuExpanded = false
+                        }) {
+                            Paragraph(
+                                text = stringResource(
+                                    id = R.string.claim_sensor
+                                )
+                            )
+                        }
+                    } else if (canBeShared) {
+                        DropdownMenuItem(onClick = {
+                            ShareSensorActivity.start(context, sensor.id)
+                            threeDotsMenuExpanded = false
+                        }) {
+                            Paragraph(
+                                text = stringResource(
+                                    id = R.string.share
+                                )
+                            )
+                        }
+                    }
+
+                    DropdownMenuItem(onClick = {
+                        TagSettingsActivity.startToRemove(context, sensor.id)
+                        threeDotsMenuExpanded = false
+                    }) {
+                        Paragraph(
+                            text = stringResource(
+                                id = R.string.remove
+                            )
+                        )
+                    }
+                }
             }
         }
     }

--- a/app/src/main/java/com/ruuvi/station/graph/ChartControlElement.kt
+++ b/app/src/main/java/com/ruuvi/station/graph/ChartControlElement.kt
@@ -262,43 +262,45 @@ fun ViewPeriodMenu(
                 tint = RuuviStationTheme.colors.accent
             )
         }
-        DropdownMenu(
-            modifier = Modifier
-                .background(color = RuuviStationTheme.colors.background),
-            expanded = daysMenuExpanded,
-            onDismissRequest = { daysMenuExpanded = false }) {
-            val periodOptions = listOf(
-                Period.All,
-                Period.Hour1,
-                Period.Hour2,
-                Period.Hour3,
-                Period.Hour6,
-                Period.Hour12,
-                Period.Day1,
-                Period.Day2,
-                Period.Day3,
-                Period.Day4,
-                Period.Day5,
-                Period.Day6,
-                Period.Day7,
-                Period.Day8,
-                Period.Day9,
-                Period.Day10,
-            )
-            for (day in periodOptions) {
-                DropdownMenuItem(onClick = {
-                    setViewPeriod.invoke(day.value)
-                    daysMenuExpanded = false
-                }) {
-                    Paragraph(text = stringResource(id = day.stringResourceId))
-                }
-            }
+        CompositionLocalProvider(LocalElevationOverlay provides null) {
+            MaterialTheme(colors = MaterialTheme.colors.copy(surface = RuuviStationTheme.colors.background)) {
+                DropdownMenu(
+                    expanded = daysMenuExpanded,
+                    onDismissRequest = { daysMenuExpanded = false }) {
+                    val periodOptions = listOf(
+                        Period.All,
+                        Period.Hour1,
+                        Period.Hour2,
+                        Period.Hour3,
+                        Period.Hour6,
+                        Period.Hour12,
+                        Period.Day1,
+                        Period.Day2,
+                        Period.Day3,
+                        Period.Day4,
+                        Period.Day5,
+                        Period.Day6,
+                        Period.Day7,
+                        Period.Day8,
+                        Period.Day9,
+                        Period.Day10,
+                    )
+                    for (day in periodOptions) {
+                        DropdownMenuItem(onClick = {
+                            setViewPeriod.invoke(day.value)
+                            daysMenuExpanded = false
+                        }) {
+                            Paragraph(text = stringResource(id = day.stringResourceId))
+                        }
+                    }
 
-            DropdownMenuItem(onClick = {
-                showMoreDialog = true
-                daysMenuExpanded = false
-            }) {
-                Paragraph(text = stringResource(id = R.string.more))
+                    DropdownMenuItem(onClick = {
+                        showMoreDialog = true
+                        daysMenuExpanded = false
+                    }) {
+                        Paragraph(text = stringResource(id = R.string.more))
+                    }
+                }
             }
         }
     }
@@ -345,61 +347,64 @@ fun ThreeDotsMenu(
             )
         }
 
-        DropdownMenu(
-            modifier = Modifier.background(color = RuuviStationTheme.colors.background),
-            expanded = threeDotsMenuExpanded,
-            onDismissRequest = { threeDotsMenuExpanded = false }
-        ) {
-            DropdownMenuItem(onClick = {
-                val uri = exportToCsv.invoke()
-                if (uri != null) {
-                    sendCsv(sensorId, uri, context)
-                }
-                threeDotsMenuExpanded = false
-            }) {
-                Paragraph(text = stringResource(id = R.string.export_history))
-            }
-            DropdownMenuItem(onClick = {
-                if (VERSION.SDK_INT < 26) {
-                    android26RequiredDialog = true
-                } else {
-                    val uri = exportToXlsx.invoke()
-                    if (uri != null) {
-                        sendXlsx(sensorId, uri, context)
+        CompositionLocalProvider(LocalElevationOverlay provides null) {
+            MaterialTheme(colors = MaterialTheme.colors.copy(surface = RuuviStationTheme.colors.background)) {
+                DropdownMenu(
+                    expanded = threeDotsMenuExpanded,
+                    onDismissRequest = { threeDotsMenuExpanded = false }
+                ) {
+                    DropdownMenuItem(onClick = {
+                        val uri = exportToCsv.invoke()
+                        if (uri != null) {
+                            sendCsv(sensorId, uri, context)
+                        }
+                        threeDotsMenuExpanded = false
+                    }) {
+                        Paragraph(text = stringResource(id = R.string.export_history))
                     }
-                    threeDotsMenuExpanded = false
-                }
-            }) {
-                Paragraph(text = stringResource(id = R.string.export_history_xlsx))
-            }
-            DropdownMenuItem(onClick = {
-                clearConfirmOpened = true
-                threeDotsMenuExpanded = false
-            }) {
-                Paragraph(text = stringResource(id = R.string.clear_view))
-            }
-            DropdownMenuItem(onClick = {
-                threeDotsMenuExpanded = false
-                changeShowStats()
-            }) {
-                val caption = if (showChartStats) {
-                    stringResource(id = R.string.chart_stat_hide)
-                } else {
-                    stringResource(id = R.string.chart_stat_show)
-                }
-                Paragraph(text = caption)
-            }
-            if (!hideIncreaseChartSize) {
-                DropdownMenuItem(onClick = {
-                    threeDotsMenuExpanded = false
-                    changeIncreasedChartSize()
-                }) {
-                    val caption = if (increasedChartSize) {
-                        stringResource(id = R.string.decrease_graph_size)
-                    } else {
-                        stringResource(id = R.string.increase_graph_size)
+                    DropdownMenuItem(onClick = {
+                        if (VERSION.SDK_INT < 26) {
+                            android26RequiredDialog = true
+                        } else {
+                            val uri = exportToXlsx.invoke()
+                            if (uri != null) {
+                                sendXlsx(sensorId, uri, context)
+                            }
+                            threeDotsMenuExpanded = false
+                        }
+                    }) {
+                        Paragraph(text = stringResource(id = R.string.export_history_xlsx))
                     }
-                    Paragraph(text = caption)
+                    DropdownMenuItem(onClick = {
+                        clearConfirmOpened = true
+                        threeDotsMenuExpanded = false
+                    }) {
+                        Paragraph(text = stringResource(id = R.string.clear_view))
+                    }
+                    DropdownMenuItem(onClick = {
+                        threeDotsMenuExpanded = false
+                        changeShowStats()
+                    }) {
+                        val caption = if (showChartStats) {
+                            stringResource(id = R.string.chart_stat_hide)
+                        } else {
+                            stringResource(id = R.string.chart_stat_show)
+                        }
+                        Paragraph(text = caption)
+                    }
+                    if (!hideIncreaseChartSize) {
+                        DropdownMenuItem(onClick = {
+                            threeDotsMenuExpanded = false
+                            changeIncreasedChartSize()
+                        }) {
+                            val caption = if (increasedChartSize) {
+                                stringResource(id = R.string.decrease_graph_size)
+                            } else {
+                                stringResource(id = R.string.increase_graph_size)
+                            }
+                            Paragraph(text = caption)
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
- Disabled LocalElevationOverlay across DashboardActivity, TopAppBar, and ChartControlElement to remove the thin white highlight (3D edge line) that appears on elevated menus in dark mode.
- Wrapped DropdownMenu components in a localized MaterialTheme, explicitly setting the surface color to the theme's background to prevent background bleed and ensure consistent rendering in both Light and Dark themes.
- Removed manual background modifiers from menus that were conflicting with the Material surface logic.