### PR TITLE
Fix deploy job failure caused by version code conflicts across branches

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -53,8 +53,8 @@ android {
         minSdkVersion 23
         targetSdkVersion 35
         compileSdk 35
-        versionCode 305015
-        versionName "3.5.15"
+        versionCode 305016
+        versionName "3.5.16"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/com/ruuvi/station/app/ui/components/Buttons.kt
+++ b/app/src/main/java/com/ruuvi/station/app/ui/components/Buttons.kt
@@ -1,10 +1,12 @@
 package com.ruuvi.station.app.ui.components
 
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
@@ -75,6 +77,42 @@ fun RuuviButton(
             Spacer(modifier = Modifier.width(RuuviStationTheme.dimensions.medium))
             LoadingStatus(color = RuuviStationTheme.colors.onInactive)
         }
+    }
+}
+
+@Composable
+fun RuuviSecondaryButton(
+    text: String,
+    modifier: Modifier = Modifier,
+    shape: Shape = RoundedCornerShape(50),
+    height: Dp = RuuviStationTheme.dimensions.buttonHeight,
+    enabled: Boolean = true,
+    onClick: () -> Unit
+) {
+    OutlinedButton(
+        modifier = modifier
+            .defaultMinSize(
+                minWidth = 150.dp,
+                minHeight = height
+            ),
+        enabled = enabled,
+        shape = shape,
+        colors = ButtonDefaults.outlinedButtonColors(
+            backgroundColor = Color.Transparent,
+            contentColor = RuuviStationTheme.colors.primary
+        ),
+        border = BorderStroke(
+            width = 2.dp,
+            color = RuuviStationTheme.colors.primary.copy(alpha = 0.35f)
+        ),
+        elevation = ruuviButtonElevation(),
+        contentPadding = PaddingValues(horizontal = RuuviStationTheme.dimensions.buttonInnerPadding),
+        onClick = { onClick() }) {
+        Text(
+            text = text,
+            style = RuuviStationTheme.typography.buttonText,
+            textAlign = TextAlign.Center
+        )
     }
 }
 

--- a/app/src/main/java/com/ruuvi/station/app/ui/components/TextEditButton.kt
+++ b/app/src/main/java/com/ruuvi/station/app/ui/components/TextEditButton.kt
@@ -84,7 +84,7 @@ fun applyStyleToDecimals(
 fun TextEditWithCaptionButton(
     value: String? = null,
     title: String,
-    icon: Painter,
+    icon: Painter? = null,
     tint: Color,
     editAction: () -> Unit
 ) {
@@ -107,12 +107,14 @@ fun TextEditWithCaptionButton(
             style = RuuviStationTheme.typography.paragraph,
             textAlign = TextAlign.End,
             text = value ?: "")
-        Icon(
-            modifier = Modifier.padding(horizontal = RuuviStationTheme.dimensions.screenPadding),
-            painter = icon,
-            tint = tint,
-            contentDescription = ""
-        )
+        if (icon != null) {
+            Icon(
+                modifier = Modifier.padding(horizontal = RuuviStationTheme.dimensions.screenPadding),
+                painter = icon,
+                tint = tint,
+                contentDescription = ""
+            )
+        }
     }
 }
 

--- a/app/src/main/java/com/ruuvi/station/dashboard/ui/DashboardActivity.kt
+++ b/app/src/main/java/com/ruuvi/station/dashboard/ui/DashboardActivity.kt
@@ -224,7 +224,7 @@ class DashboardActivity : NfcActivity(), KodeinAware {
                                 .fillMaxSize()
                                 .padding(paddingValues)
                         ) {
-                            sensors?.let {
+                            sensors.let {
                                 if (it.isEmpty()) {
                                     EmptyDashboard(
                                         signedIn,
@@ -869,7 +869,7 @@ fun ItemValues(
 ) {
     val valuesToDisplay =
         if (dropFirst) {
-            sensor.valuesToDisplay.subList(1, sensor.valuesToDisplay.size)
+            sensor.valuesToDisplay.drop(1)
         } else {
             sensor.valuesToDisplay
         }

--- a/app/src/main/java/com/ruuvi/station/database/domain/LocalDatabase.kt
+++ b/app/src/main/java/com/ruuvi/station/database/domain/LocalDatabase.kt
@@ -13,7 +13,16 @@ import com.ruuvi.station.database.tables.*
 class LocalDatabase {
     companion object {
         const val NAME = "LocalDatabase"
-        const val VERSION = 39
+        const val VERSION = 40
+    }
+
+    @Migration(version = 40, database = LocalDatabase::class)
+    class Migration40SensorSettings(table: Class<SensorSettings>) : AlterTableMigration<SensorSettings>(table) {
+        override fun onPreMigrate() {
+            super.onPreMigrate()
+            addColumn(SQLiteType.TEXT, "description")
+            addColumn(SQLiteType.INTEGER, "descriptionTimestamp")
+        }
     }
 
     @Migration(version = 39, database = LocalDatabase::class)

--- a/app/src/main/java/com/ruuvi/station/database/domain/SensorSettingsRepository.kt
+++ b/app/src/main/java/com/ruuvi/station/database/domain/SensorSettingsRepository.kt
@@ -180,4 +180,14 @@ class SensorSettingsRepository {
             }
         }
     }
+
+    fun newDescription(sensorId: String, description: String?, timestamp: Long) {
+        getSensorSettings(sensorId)?.let { settings ->
+            if (timestamp > settings.descriptionTimestamp) {
+                settings.description = description
+                settings.descriptionTimestamp = timestamp
+                settings.update()
+            }
+        }
+    }
 }

--- a/app/src/main/java/com/ruuvi/station/database/tables/FavouriteSensorQuery.kt
+++ b/app/src/main/java/com/ruuvi/station/database/tables/FavouriteSensorQuery.kt
@@ -49,6 +49,8 @@ data class FavouriteSensorQuery(
     var defaultDisplayOrder: Boolean = true,
     @Column
     var displayOrder: String? = null,
+    @Column
+    var description: String? = null,
     // RuuviTagEntity
     @Column
     var latestId: String? = null,
@@ -123,6 +125,7 @@ data class FavouriteSensorQuery(
             SensorSettings_Table.firmware.withTable(),
             SensorSettings_Table.defaultDisplayOrder.withTable(),
             SensorSettings_Table.displayOrder.withTable(),
+            SensorSettings_Table.description.withTable(),
             RuuviTagEntity_Table.id.withTable().`as`("latestId"),
             RuuviTagEntity_Table.rssi.withTable(),
             RuuviTagEntity_Table.temperature.withTable(),

--- a/app/src/main/java/com/ruuvi/station/database/tables/SensorSettings.kt
+++ b/app/src/main/java/com/ruuvi/station/database/tables/SensorSettings.kt
@@ -79,16 +79,6 @@ data class SensorSettings(
         networkSensor = true
         subscriptionName = sensor.subscription?.subscriptionName
         lastUpdated = sensor.lastUpdated
-//        sensor.settings?.let {
-//            if ((it.displayOrder_lastUpdated ?: 0) > displayOrderTimestamp) {
-//                displayOrder = it.displayOrder
-//                displayOrderTimestamp = it.displayOrder_lastUpdated ?: 0
-//            }
-//            if ((it.description_lastUpdated ?: 0) > descriptionTimestamp) {
-//                description = it.description
-//                descriptionTimestamp = it.description_lastUpdated ?: 0
-//            }
-//        }
         update()
     }
 }

--- a/app/src/main/java/com/ruuvi/station/database/tables/SensorSettings.kt
+++ b/app/src/main/java/com/ruuvi/station/database/tables/SensorSettings.kt
@@ -62,6 +62,10 @@ data class SensorSettings(
     var defaultDisplayOrderTimestamp: Long = 0L,
     @Column
     var displayOrderTimestamp: Long = 0L,
+    @Column
+    var description: String? = null,
+    @Column
+    var descriptionTimestamp: Long = 0L,
 ): BaseModel() {
     val displayName get() = if (name.isNullOrEmpty()) id else name.toString()
 
@@ -75,6 +79,16 @@ data class SensorSettings(
         networkSensor = true
         subscriptionName = sensor.subscription?.subscriptionName
         lastUpdated = sensor.lastUpdated
+//        sensor.settings?.let {
+//            if ((it.displayOrder_lastUpdated ?: 0) > displayOrderTimestamp) {
+//                displayOrder = it.displayOrder
+//                displayOrderTimestamp = it.displayOrder_lastUpdated ?: 0
+//            }
+//            if ((it.description_lastUpdated ?: 0) > descriptionTimestamp) {
+//                description = it.description
+//                descriptionTimestamp = it.description_lastUpdated ?: 0
+//            }
+//        }
         update()
     }
 }

--- a/app/src/main/java/com/ruuvi/station/network/data/response/SensorDenseResponse.kt
+++ b/app/src/main/java/com/ruuvi/station/network/data/response/SensorDenseResponse.kt
@@ -37,7 +37,10 @@ data class SensorSettings(
     val defaultDisplayOrder: String?,
     val displayOrder_lastUpdated: Long?,
     val defaultDisplayOrder_lastUpdated: Long?,
+    val description: String? = null,
+    val description_lastUpdated: Long? = null
 )
 
 const val SensorSettings_displayOrder = "displayOrder"
 const val SensorSettings_defaultDisplayOrder = "defaultDisplayOrder"
+const val SensorSettings_description = "description"

--- a/app/src/main/java/com/ruuvi/station/network/domain/NetworkDataSyncInteractor.kt
+++ b/app/src/main/java/com/ruuvi/station/network/domain/NetworkDataSyncInteractor.kt
@@ -363,13 +363,16 @@ class NetworkDataSyncInteractor (
 
     private fun updateSensorSettings(userInfoData: SensorsDenseResponseBody) {
         userInfoData.sensors.forEach { sensor ->
-            Timber.d("updateSensorSettings: $sensor displayOrder = ${sensor.settings?.displayOrder} defaultDisplayOrder = ${sensor.settings?.defaultDisplayOrder}")
+            Timber.d("updateSensorSettings: $sensor displayOrder = ${sensor.settings?.displayOrder} defaultDisplayOrder = ${sensor.settings?.defaultDisplayOrder} description = ${sensor.settings?.description}")
 
             sensor.settings?.displayOrder?.let { displayOrder ->
                 sensorSettingsRepository.newDisplayOrder(sensor.sensor, displayOrder, sensor.settings.displayOrder_lastUpdated ?: 0)
             }
             sensor.settings?.defaultDisplayOrder?.let { defaultDisplayOrder ->
                 sensorSettingsRepository.updateUseDefaultSensorOrder(sensor.sensor, defaultDisplayOrder.toBooleanExtra(), sensor.settings.defaultDisplayOrder_lastUpdated ?: 0)
+            }
+            sensor.settings?.description?.let { description ->
+                sensorSettingsRepository.newDescription(sensor.sensor, description, sensor.settings.description_lastUpdated ?: 0)
             }
         }
     }

--- a/app/src/main/java/com/ruuvi/station/tag/domain/RuuviTag.kt
+++ b/app/src/main/java/com/ruuvi/station/tag/domain/RuuviTag.kt
@@ -30,6 +30,7 @@ data class RuuviTag(
     var defaultDisplayOrder: Boolean,
     var displayOrder: List<UnitType>,
     var possibleDisplayOptions: List<UnitType>,
+    val description: String?,
     val valuesToDisplay: List<EnvironmentValue>,
     val latestMeasurement: SensorMeasurements?
 ) {
@@ -205,5 +206,6 @@ val ruuviTagPreview = RuuviTag(
     displayOrder = listOf(),
     valuesToDisplay = listOf(),
     possibleDisplayOptions = listOf(),
+    description = "",
     latestMeasurement = sensorMeasurementsPreview
 )

--- a/app/src/main/java/com/ruuvi/station/tag/domain/TagConverter.kt
+++ b/app/src/main/java/com/ruuvi/station/tag/domain/TagConverter.kt
@@ -40,6 +40,7 @@ class TagConverter(
             defaultDisplayOrder = sensorSettings.defaultDisplayOrder,
             displayOrder = listOf(),
             possibleDisplayOptions = listOf(),
+            description = sensorSettings.description,
             valuesToDisplay = listOf(),
             latestMeasurement = SensorMeasurements(
                 aqi = unitsConverter.getAqiEnviromentValue(AQI.getAQI(
@@ -261,6 +262,7 @@ class TagConverter(
             defaultDisplayOrder = entity.defaultDisplayOrder,
             displayOrder = displayOrder,
             possibleDisplayOptions = possibleOptionsFiltered,
+            description = entity.description,
             valuesToDisplay = valuesToDisplay,
             latestMeasurement = entity.latestId?.let {
                 SensorMeasurements(

--- a/app/src/main/java/com/ruuvi/station/tagsettings/di/TagSettingsInjectionModule.kt
+++ b/app/src/main/java/com/ruuvi/station/tagsettings/di/TagSettingsInjectionModule.kt
@@ -5,6 +5,7 @@ import com.ruuvi.station.tagsettings.ui.BackgroundViewModel
 import com.ruuvi.station.tagsettings.ui.RemoveSensorViewModel
 import com.ruuvi.station.tagsettings.ui.TagSettingsViewModel
 import com.ruuvi.station.tagsettings.ui.led_control.LedControlViewModel
+import com.ruuvi.station.tagsettings.ui.notes.NotesViewModel
 import com.ruuvi.station.tagsettings.ui.visible_measurements.VisibleMeasurementsViewModel
 import org.kodein.di.Kodein
 import org.kodein.di.generic.bind
@@ -33,6 +34,10 @@ object TagSettingsInjectionModule {
 
         bind<LedControlViewModel>() with factory { sensorId: String ->
             LedControlViewModel(sensorId, instance(), instance())
+        }
+
+        bind<NotesViewModel>() with factory { sensorId: String ->
+            NotesViewModel(sensorId, instance())
         }
 
         bind<RemoveSensorViewModel>() with factory { args: RemoveSensorViewModelArgs ->

--- a/app/src/main/java/com/ruuvi/station/tagsettings/domain/TagSettingsInteractor.kt
+++ b/app/src/main/java/com/ruuvi/station/tagsettings/domain/TagSettingsInteractor.kt
@@ -12,6 +12,7 @@ import com.ruuvi.station.image.ImageInteractor
 import com.ruuvi.station.image.ImageSource
 import com.ruuvi.station.network.data.response.SensorSettings_defaultDisplayOrder
 import com.ruuvi.station.network.data.response.SensorSettings_displayOrder
+import com.ruuvi.station.network.data.response.SensorSettings_description
 import com.ruuvi.station.network.domain.RuuviNetworkInteractor
 import com.ruuvi.station.tag.domain.RuuviTag
 import com.ruuvi.station.units.model.UnitType.*
@@ -189,6 +190,20 @@ class TagSettingsInteractor(
                 sensorId = sensorId,
                 name = SensorSettings_displayOrder,
                 value = displayOrder,
+                timestamp = timestamp
+            )
+        }
+    }
+
+    fun updateDescription(sensorId: String, description: String?) {
+        val sensorSettings = getSensorSettings(sensorId)
+        val timestamp = Date().time/1000
+        sensorSettingsRepository.newDescription(sensorId, description, timestamp)
+        if (sensorSettings?.networkSensor == true) {
+            networkInteractor.updateSensorSetting(
+                sensorId = sensorId,
+                name = SensorSettings_description,
+                value = description ?: "",
                 timestamp = timestamp
             )
         }

--- a/app/src/main/java/com/ruuvi/station/tagsettings/ui/SensorSettingsElements.kt
+++ b/app/src/main/java/com/ruuvi/station/tagsettings/ui/SensorSettingsElements.kt
@@ -1,6 +1,5 @@
 package com.ruuvi.station.tagsettings.ui
 
-import android.net.Uri
 import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.*
 import androidx.compose.foundation.layout.*

--- a/app/src/main/java/com/ruuvi/station/tagsettings/ui/SensorSettingsElements.kt
+++ b/app/src/main/java/com/ruuvi/station/tagsettings/ui/SensorSettingsElements.kt
@@ -1,6 +1,7 @@
 package com.ruuvi.station.tagsettings.ui
 
 import android.net.Uri
+import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.*
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.text.KeyboardActions
@@ -25,6 +26,7 @@ import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
@@ -35,6 +37,7 @@ import com.ruuvi.station.app.ui.UiText
 import com.ruuvi.station.app.ui.components.*
 import com.ruuvi.station.app.ui.components.dialog.CustomContentDialog
 import com.ruuvi.station.app.ui.theme.RuuviStationTheme
+import com.ruuvi.station.app.ui.theme.RuuviTheme
 import com.ruuvi.station.calibration.ui.CalibrationSettingsGroup
 import com.ruuvi.station.dfu.ui.FirmwareGroup
 import com.ruuvi.station.network.ui.claim.ClaimSensorActivity
@@ -45,6 +48,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collectLatest
 import okhttp3.internal.toHexString
 import timber.log.Timber
+import androidx.core.net.toUri
 
 @Composable
 fun SensorSettings(
@@ -91,6 +95,26 @@ fun SensorSettings(
                 onNavigate.invoke(SensorSettingsRoutes.VISIBLE_MEASUREMENTS)
             }
         }
+
+        if (userLoggedIn) {
+            DividerRuuvi()
+
+            TextEditWithCaptionButton(
+                title = stringResource(R.string.notes),
+                icon = if (sensorOwnedByUser) painterResource(id = R.drawable.edit_20) else null,
+                tint = RuuviStationTheme.colors.accent
+            ) {
+                if (sensorOwnedByUser) {
+                    onNavigate.invoke(SensorSettingsRoutes.NOTES)
+                }
+            }
+
+            sensorState.description?.takeIf { it.isNotEmpty() }?.let {
+                DividerRuuvi()
+                NotesGroup(sensorState = sensorState)
+            }
+        }
+
         if (sensorState.isAir()) {
             DividerRuuvi()
 
@@ -177,7 +201,7 @@ fun SensorSettingsImage(
         Timber.d("Image path ${sensorState.userBackground} ")
 
         if (sensorState.userBackground != null) {
-            val uri = Uri.parse(sensorState.userBackground)
+            val uri = sensorState.userBackground.toUri()
 
             if (uri.path != null) {
                 AsyncImage(
@@ -510,17 +534,64 @@ fun BatteryInfoItem (
 }
 
 @Composable
-@Preview
-fun preview() {
-    Column() {
-        MoreInfoItem(
-            title = stringResource(id = R.string.mac_address),
-            value = "sensorState.id"
+@Preview(showBackground = true)
+fun SensorSettingsPreview() {
+    RuuviTheme {
+        Column {
+            MoreInfoItem(
+                title = stringResource(id = R.string.mac_address),
+                value = "sensorState.id"
+            )
+            MoreInfoItem(
+                title = stringResource(id = R.string.mac_address),
+                value = "fasfasasdafs"
+            )
+        }
+    }
+}
+
+@Composable
+fun NotesGroup(sensorState: RuuviTag) {
+    var expanded by remember { mutableStateOf(false) }
+    var hasOverflow by remember { mutableStateOf(false) }
+    val notes = sensorState.description ?: ""
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = RuuviStationTheme.dimensions.screenPadding)
+            .animateContentSize()
+    ) {
+        Spacer(modifier = Modifier.height(RuuviStationTheme.dimensions.medium))
+
+        Text(
+            text = notes,
+            style = RuuviStationTheme.typography.paragraph,
+            maxLines = if (expanded) Int.MAX_VALUE else 3,
+            overflow = TextOverflow.Ellipsis,
+            onTextLayout = { textLayoutResult ->
+                if (!expanded) {
+                    hasOverflow = textLayoutResult.hasVisualOverflow || textLayoutResult.lineCount > 3
+                }
+            }
         )
-        MoreInfoItem(
-            title = stringResource(id = R.string.mac_address),
-            value = "fasfasasdafs"
-        )
+
+        if (hasOverflow) {
+            Spacer(modifier = Modifier.height(RuuviStationTheme.dimensions.medium))
+
+            Box(
+                modifier = Modifier.fillMaxWidth(),
+                contentAlignment = Alignment.Center
+            ) {
+                RuuviSecondaryButton(
+                    text = if (expanded) stringResource(R.string.show_less) else stringResource(id = R.string.show_more),
+                ) {
+                    expanded = !expanded
+                }
+            }
+        }
+
+        Spacer(modifier = Modifier.height(RuuviStationTheme.dimensions.mediumPlus))
     }
 }
 

--- a/app/src/main/java/com/ruuvi/station/tagsettings/ui/SensorSettingsRoutes.kt
+++ b/app/src/main/java/com/ruuvi/station/tagsettings/ui/SensorSettingsRoutes.kt
@@ -8,6 +8,7 @@ object SensorSettingsRoutes {
     const val SENSOR_REMOVE = "sensor_remove"
     const val VISIBLE_MEASUREMENTS = "visible_measurements"
     const val LED_CONTROL = "led_control"
+    const val NOTES = "notes"
 
 
     fun getTitleByRoute(context: Context, route: String): String {
@@ -16,6 +17,7 @@ object SensorSettingsRoutes {
             SENSOR_REMOVE -> context.getString(R.string.tagsettings_sensor_remove)
             VISIBLE_MEASUREMENTS -> context.getString(R.string.visible_measurements)
             LED_CONTROL -> context.getString(R.string.led_brightness_control)
+            NOTES -> context.getString(R.string.notes)
             else -> context.getString(R.string.sensor_settings)
         }
     }

--- a/app/src/main/java/com/ruuvi/station/tagsettings/ui/TagSettingsActivity.kt
+++ b/app/src/main/java/com/ruuvi/station/tagsettings/ui/TagSettingsActivity.kt
@@ -35,6 +35,8 @@ import com.ruuvi.station.tagsettings.di.RemoveSensorViewModelArgs
 import com.ruuvi.station.tagsettings.di.TagSettingsViewModelArgs
 import com.ruuvi.station.tagsettings.ui.led_control.LedControlScreen
 import com.ruuvi.station.tagsettings.ui.led_control.LedControlViewModel
+import com.ruuvi.station.tagsettings.ui.notes.Notes
+import com.ruuvi.station.tagsettings.ui.notes.NotesViewModel
 import com.ruuvi.station.tagsettings.ui.visible_measurements.VisibleMeasurements
 import com.ruuvi.station.tagsettings.ui.visible_measurements.VisibleMeasurementsViewModel
 import com.ruuvi.station.util.extensions.viewModel
@@ -200,6 +202,25 @@ class TagSettingsActivity : AppCompatActivity(), KodeinAware {
                                 }
                                 LedControlScreen(
                                     viewModel = ledControlViewModel
+                                )
+                            }
+
+                            composable(
+                                route = SensorSettingsRoutes.NOTES,
+                                enterTransition = enterTransition,
+                                exitTransition = exitTransition
+                            ) {
+                                val notesViewModel: NotesViewModel by viewModel() {
+                                    intent.getStringExtra(TAG_ID)?.let {
+                                        it
+                                    }
+                                }
+                                val note by notesViewModel.note.collectAsStateWithLifecycle()
+                                Notes(
+                                    note = note,
+                                    onAction = notesViewModel::onAction,
+                                    effects = notesViewModel.effects,
+                                    onNavigateBack = { navController.popBackStack() }
                                 )
                             }
                         }

--- a/app/src/main/java/com/ruuvi/station/tagsettings/ui/notes/Notes.kt
+++ b/app/src/main/java/com/ruuvi/station/tagsettings/ui/notes/Notes.kt
@@ -1,0 +1,108 @@
+package com.ruuvi.station.tagsettings.ui.notes
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.OutlinedTextField
+import androidx.compose.material.Text
+import androidx.compose.material.TextFieldDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.unit.dp
+import com.ruuvi.station.app.ui.components.RuuviButton
+import com.ruuvi.station.app.ui.theme.RuuviStationTheme
+import com.ruuvi.station.app.ui.theme.RuuviTheme
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import com.ruuvi.station.R
+
+@Composable
+fun Notes(
+    modifier: Modifier = Modifier,
+    note: String,
+    onAction: (NotesActions) -> Unit,
+    effects: SharedFlow<NotesEffect>,
+    onNavigateBack: () -> Unit
+) {
+    LaunchedEffect(effects) {
+        effects.collect { effect ->
+            when (effect) {
+                is NotesEffect.NoteUpdated -> onNavigateBack()
+            }
+        }
+    }
+
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(horizontal = RuuviStationTheme.dimensions.screenPadding),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Spacer(modifier = Modifier.height(RuuviStationTheme.dimensions.screenPadding))
+
+        OutlinedTextField(
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(1f)
+                .border(
+                    width = 2.dp,
+                    color = RuuviStationTheme.colors.accent,
+                    shape = RoundedCornerShape(RuuviStationTheme.dimensions.extended)
+                ),
+            value = note,
+            onValueChange = { onAction(NotesActions.EditNote(it)) },
+            shape = RoundedCornerShape(RuuviStationTheme.dimensions.extended),
+            colors = TextFieldDefaults.outlinedTextFieldColors(
+                cursorColor = RuuviStationTheme.colors.accent,
+                focusedBorderColor = androidx.compose.ui.graphics.Color.Transparent,
+                unfocusedBorderColor = androidx.compose.ui.graphics.Color.Transparent,
+                backgroundColor = RuuviStationTheme.colors.background
+            ),
+            textStyle = RuuviStationTheme.typography.paragraph
+        )
+
+        Text(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = RuuviStationTheme.dimensions.small),
+            text = "${note.length}/1000",
+            style = RuuviStationTheme.typography.paragraphSmall,
+            textAlign = TextAlign.End,
+            color = RuuviStationTheme.colors.secondaryTextColor
+        )
+
+        Spacer(modifier = Modifier.height(RuuviStationTheme.dimensions.medium))
+
+        RuuviButton(
+            text = stringResource(id = R.string.update),
+            onClick = { onAction(NotesActions.UpdateNote) }
+        )
+
+        Spacer(modifier = Modifier.height(RuuviStationTheme.dimensions.screenPadding))
+    }
+}
+
+@PreviewLightDark
+@Composable
+fun NotesPreview() {
+    RuuviTheme {
+        Notes(
+            note = "1. \n2. \n3. \n4. \n5. ",
+            onAction = {},
+            effects = MutableSharedFlow(),
+            onNavigateBack = {},
+            modifier = Modifier.background(RuuviStationTheme.colors.background)
+        )
+    }
+}

--- a/app/src/main/java/com/ruuvi/station/tagsettings/ui/notes/NotesActions.kt
+++ b/app/src/main/java/com/ruuvi/station/tagsettings/ui/notes/NotesActions.kt
@@ -1,0 +1,10 @@
+package com.ruuvi.station.tagsettings.ui.notes
+
+sealed interface NotesActions {
+    data class EditNote(val note: String): NotesActions
+    object UpdateNote: NotesActions
+}
+
+sealed interface NotesEffect {
+    object NoteUpdated : NotesEffect
+}

--- a/app/src/main/java/com/ruuvi/station/tagsettings/ui/notes/NotesViewModel.kt
+++ b/app/src/main/java/com/ruuvi/station/tagsettings/ui/notes/NotesViewModel.kt
@@ -1,0 +1,44 @@
+package com.ruuvi.station.tagsettings.ui.notes
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.ruuvi.station.tagsettings.domain.TagSettingsInteractor
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.launch
+
+class NotesViewModel(
+    val sensorId: String,
+    private val interactor: TagSettingsInteractor,
+): ViewModel() {
+
+    private val _note = MutableStateFlow<String>(
+        interactor.getFavouriteSensorById(sensorId)?.description ?: ""
+    )
+    val note: StateFlow<String> = _note
+
+    private val _effects = MutableSharedFlow<NotesEffect>(extraBufferCapacity = 1)
+    val effects = _effects.asSharedFlow()
+
+    fun onAction(action: NotesActions) {
+        when (action) {
+            is NotesActions.EditNote -> editNote(action.note)
+            is NotesActions.UpdateNote -> updateNote()
+        }
+    }
+
+    private fun editNote(newNote: String) {
+        if (newNote.length <= 1000) {
+            _note.value = newNote
+        }
+    }
+
+    private fun updateNote() {
+        interactor.updateDescription(sensorId, _note.value)
+        viewModelScope.launch {
+            _effects.emit(NotesEffect.NoteUpdated)
+        }
+    }
+}

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -829,6 +829,10 @@ Wenn die Beanspruchung nicht erfolgreich war oder NFC auf Ihrem Gerät nicht ver
     <string name="visible_measurements_description">Hier kannst du auswählen, welche Messwerte du sehen möchtest und in welcher Reihenfolge. Deaktiviere den Schalter „Standard verwenden“, um die Einstellungen anzupassen.</string>
     <string name="visible_measurements_last_element_message">Die letzte sichtbare Messung kann nicht entfernt werden. Lassen Sie mindestens eine Messung in der Liste der sichtbaren Messungen.</string>
     <string name="visible_measurements_use_default">Standard verwenden</string>
+    <string name="notes">Notizen</string>
+    <string name="show_more">Mehr anzeigen</string>
+    <string name="show_less">Weniger anzeigen</string>
+    <string name="update">Aktualisieren</string>
     <string name="voc_index">VOC-Index</string>
     <string name="voc_with_unit">VOC-Index (%1$s)</string>
     <string name="volatile_organic_compounds">Index flüchtiger organischer Verbindungen</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -818,6 +818,10 @@
     <string name="visible_measurements_description">Tällä sivulla voit valita, mitkä mittaukset haluat nähdä ja missä järjestyksessä. Poista "Käytä oletusta" -valinta muokataksesi asetuksia.</string>
     <string name="visible_measurements_last_element_message">Viimeistä näkyvää mittausta ei voi poistaa. Jätä Näytettävät mittaukset -luetteloon vähintään yksi mittaus.</string>
     <string name="visible_measurements_use_default">Käytä oletusta</string>
+    <string name="notes">Muistiinpanot</string>
+    <string name="show_more">Näytä lisää</string>
+    <string name="show_less">Näytä vähemmän</string>
+    <string name="update">Päivitä</string>
     <string name="voc_index">VOC-indeksi</string>
     <string name="voc_with_unit">VOC-indeksi (%1$s)</string>
     <string name="volatile_organic_compounds">Haihtuvien orgaanisten yhdisteiden indeksi</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -824,6 +824,10 @@
     <string name="visible_measurements_description">Ici, vous pouvez choisir quelles mesures afficher et dans quel ordre. Désactivez l’option « Utiliser par défaut » pour personnaliser les paramètres.</string>
     <string name="visible_measurements_last_element_message">La dernière mesure visible ne peut pas être supprimée. Gardez au moins une mesure dans la liste des mesures visibles.</string>
     <string name="visible_measurements_use_default">Utiliser par défaut</string>
+    <string name="notes">Notes</string>
+    <string name="show_more">Afficher plus</string>
+    <string name="show_less">Afficher moins</string>
+    <string name="update">Mettre à jour</string>
     <string name="voc_index">Indice COV</string>
     <string name="voc_with_unit">Indice COV (%1$s)</string>
     <string name="volatile_organic_compounds">Indice des composés organiques volatils</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -567,6 +567,10 @@
     <string name="visible_measurements_change_use_default_confirmation">Masz aktywne powiadomienie skonfigurowane dla %1$s. Jeśli zmienisz to ustawienie, zostanie ono dezaktywowane. Czy chcesz kontynuować?</string>
     <string name="visible_measurements_change_use_default_multiple_alerts_confirmation">Masz aktywne powiadomienia skonfigurowane dla %1$s. Jeśli zmienisz to ustawienie, zostaną one dezaktywowane. Czy chcesz kontynuować?</string>
     <string name="visible_measurements_last_element_message">Nie można usunąć ostatniego widocznego pomiaru. Pozostaw co najmniej jeden pomiar na liście widocznych pomiarów.</string>
+    <string name="notes">Notatki</string>
+    <string name="show_more">Pokaż więcej</string>
+    <string name="show_less">Pokaż mniej</string>
+    <string name="update">Aktualizuj</string>
     <string name="voc_index">Indeks LZO</string>
     <string name="voc_with_unit">Indeks LZO (%1$s)</string>
     <string name="volatile_organic_compounds">Indeks lotnych związków organicznych</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -629,6 +629,10 @@
     <string name="visible_measurements_description">Здесь вы можете выбрать, какие измерения отображать и в каком порядке. Отключите переключатель «Использовать по умолчанию», чтобы настроить параметры.</string>
     <string name="visible_measurements_last_element_message">Невозможно удалить последнюю видимую величину. Оставьте как минимум одно измерение в списке видимых измерений.</string>
     <string name="visible_measurements_use_default">Использовать по умолчанию</string>
+    <string name="notes">Заметки</string>
+    <string name="show_more">Показать больше</string>
+    <string name="show_less">Показать меньше</string>
+    <string name="update">Обновить</string>
     <string name="voc_index">Индекс ЛОС</string>
     <string name="voc_with_unit">Индекс ЛОС (%1$s)</string>
     <string name="volatile_organic_compounds">Индекс летучих органических соединений</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -819,6 +819,10 @@
     <string name="visible_measurements_description">Här kan du välja vilka mätvärden du vill se och i vilken ordning. Stäng av "Använd standard" för att anpassa inställningarna.</string>
     <string name="visible_measurements_last_element_message">Den sista synliga mätningen kan inte tas bort. Lämna minst en mätning i listan över synliga mätningar.</string>
     <string name="visible_measurements_use_default">Använd standard</string>
+    <string name="notes">Anteckningar</string>
+    <string name="show_more">Visa mer</string>
+    <string name="show_less">Visa mindre</string>
+    <string name="update">Uppdatera</string>
     <string name="voc_index">VOC-index</string>
     <string name="voc_with_unit">VOC-index (%1$s)</string>
     <string name="volatile_organic_compounds">Index för flyktiga organiska föreningar</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -828,6 +828,10 @@
     <string name="visible_measurements_description">Here, you can choose which measurements you\'d like to see and in what order. Switch the "Use default" toggle off to customise the settings.</string>
     <string name="visible_measurements_last_element_message">The last visible measurement cannot be removed. Keep at least one measurement in the Visible measurements list.</string>
     <string name="visible_measurements_use_default">Use default</string>
+    <string name="notes">Notes</string>
+    <string name="show_more">Show more</string>
+    <string name="show_less">Show less</string>
+    <string name="update">Update</string>
     <string name="voc_index">VOC index</string>
     <string name="voc_with_unit">VOC index (%1$s)</string>
     <string name="volatile_organic_compounds">Volatile organic compounds index</string>

--- a/scripts/ci/update_l10n.sh
+++ b/scripts/ci/update_l10n.sh
@@ -95,6 +95,9 @@ for lang in $languages; do
 
   if [ -s "$previous_file" ]; then
     while IFS= read -r line; do
+      if [[ "$line" != *"<string name=\""* ]]; then
+        continue
+      fi
       ident=$(echo "$line" | sed -n 's/.*<string name="\([^"]*\)".*/\1/p')
       if [ -n "$ident" ] && ! grep -q "name=\"$ident\"" "$filename"; then
         echo "$line" >> "$filename"

--- a/scripts/ci/update_l10n.sh
+++ b/scripts/ci/update_l10n.sh
@@ -62,6 +62,12 @@ for lang in $languages; do
     filename="app/src/main/res/values-${lang}/strings.xml"
   fi
 
+  # Preserve previous file to keep local strings that are not yet in station.localization
+  previous_file=$(mktemp)
+  if [ -f "$filename" ]; then
+    cp "$filename" "$previous_file"
+  fi
+
   # Create a new file and write the XML header
   echo '<?xml version="1.0" encoding="utf-8"?>' > "$filename"
   echo '<resources>' >> "$filename"
@@ -85,8 +91,19 @@ for lang in $languages; do
 
       append_xml "$filename" "$ident" "$text"
     done
-    echo '</resources>' >> "$filename"
   fi
+
+  if [ -s "$previous_file" ]; then
+    while IFS= read -r line; do
+      ident=$(echo "$line" | sed -n 's/.*<string name="\([^"]*\)".*/\1/p')
+      if [ -n "$ident" ] && ! grep -q "name=\"$ident\"" "$filename"; then
+        echo "$line" >> "$filename"
+      fi
+    done < "$previous_file"
+  fi
+
+  rm -f "$previous_file"
+  echo '</resources>' >> "$filename"
 done
 
 rm -r -f station.localization

--- a/scripts/ci/update_l10n.sh
+++ b/scripts/ci/update_l10n.sh
@@ -94,11 +94,12 @@ for lang in $languages; do
   fi
 
   if [ -s "$previous_file" ]; then
+    string_regex='^[[:space:]]*<string[[:space:]]+name="([^"]+)"[^>]*>.*</string>[[:space:]]*$'
     while IFS= read -r line; do
-      if [[ "$line" != *"<string name=\""* ]]; then
+      if [[ ! "$line" =~ $string_regex ]]; then
         continue
       fi
-      ident=$(echo "$line" | sed -n 's/.*<string name="\([^"]*\)".*/\1/p')
+      ident="${BASH_REMATCH[1]}"
       if [ -n "$ident" ] && ! grep -q "name=\"$ident\"" "$filename"; then
         echo "$line" >> "$filename"
       fi

--- a/scripts/ci/version_increment.sh
+++ b/scripts/ci/version_increment.sh
@@ -1,27 +1,39 @@
 #!/bin/bash
 
-# Read the current version name from build.gradle
+# Read the current version name and code from build.gradle
 current_version_name=$(grep -oP 'versionName "\K\d+\.\d+\.\d+' app/build.gradle)
+current_version_code=$(grep -oP 'versionCode \d+' app/build.gradle | grep -oP '\d+')
 
-# Extract major, minor, and patch version numbers
-major_version=$(echo $current_version_name | cut -d'.' -f1)
-minor_version=$(echo $current_version_name | cut -d'.' -f2)
-patch_version=$(echo $current_version_name | cut -d'.' -f3)
+# Fetch all remote branch tips to detect higher version codes already deployed from other branches
+git fetch origin --depth 1 '+refs/heads/*:refs/remotes/origin/*' 2>/dev/null || true
 
-# Increment the patch version
+# Find the highest version code across all remote branches to avoid conflicts
+highest_version_code=$current_version_code
+highest_version_name=$current_version_name
+
+for remote_ref in $(git for-each-ref --format='%(refname:short)' 'refs/remotes/origin/' 2>/dev/null | grep -v 'HEAD'); do
+    remote_code=$(git show "${remote_ref}:app/build.gradle" 2>/dev/null | grep -oP 'versionCode \d+' | grep -oP '\d+') || continue
+    if [[ -n "$remote_code" ]] && (( remote_code > highest_version_code )); then
+        highest_version_code=$remote_code
+        remote_name=$(git show "${remote_ref}:app/build.gradle" 2>/dev/null | grep -oP 'versionName "\K[0-9.]+')
+        if [[ -n "$remote_name" ]]; then
+            highest_version_name=$remote_name
+        fi
+    fi
+done
+
+# Extract major, minor, and patch version numbers from the highest known version
+major_version=$(echo $highest_version_name | cut -d'.' -f1)
+minor_version=$(echo $highest_version_name | cut -d'.' -f2)
+patch_version=$(echo $highest_version_name | cut -d'.' -f3)
+
+# Increment the patch version and version code from the highest base
 ((patch_version++))
-
-# Construct the incremented version name
 incremented_version_name="$major_version.$minor_version.$patch_version"
+incremented_version_code=$((highest_version_code + 1))
 
 # Update the version name in build.gradle
 sed -i "s/versionName \"$current_version_name\"/versionName \"$incremented_version_name\"/" app/build.gradle
-
-# Read the current version code from build.gradle
-current_version_code=$(grep -oP 'versionCode \d+' app/build.gradle | grep -oP '\d+')
-
-# Increment the version code
-incremented_version_code=$((current_version_code + 1))
 
 # Update the version code in build.gradle
 sed -i "s/versionCode $current_version_code/versionCode $incremented_version_code/" app/build.gradle


### PR DESCRIPTION
The `deploy.yml` "build" job was failing with the Google Play error:

> You cannot rollout this release because it does not allow any existing users to upgrade to the newly added APKs.

## Root Cause

`version_increment.sh` only read the local `app/build.gradle` to determine the current version code and incremented it by 1. When multiple branches (e.g., `qa/week_22_2026` and `feature/notes`) started from the same base version code (305015), the first branch to deploy incremented to 305016 and succeeded. The second branch also incremented from 305015 to 305016, but Google Play rejected it since 305016 was already live on the internal track.

## Fix

Updated `scripts/ci/version_increment.sh` to:

- **Fetch all remote branch tips** before determining the version to use, via `git fetch origin --depth 1 '+refs/heads/*:refs/remotes/origin/*'`
- **Scan all remote branches** for their current version codes
- **Increment from the highest version found** across all branches, ensuring every deploy uses a version code strictly greater than any version already deployed from any branch

For the failing scenario: the script now detects that `origin/qa/week_22_2026` already has version 305016, sets the base to 305016, and increments to 305017 instead of producing the conflicting 305016.