### PR TITLE
 Toast can retrigger when user visits subpage in sensor settings #1560

### DIFF
--- a/app/src/main/java/com/ruuvi/station/alarm/ui/AlarmItemsViewModel.kt
+++ b/app/src/main/java/com/ruuvi/station/alarm/ui/AlarmItemsViewModel.kt
@@ -30,7 +30,7 @@ class AlarmItemsViewModel(
     val tagSettingsInteractor: TagSettingsInteractor
 ): ViewModel() {
 
-    private val _uiEvent = MutableSharedFlow<UiEvent> (1)
+    private val _uiEvent = MutableSharedFlow<UiEvent> (0,1)
     val uiEvent: SharedFlow<UiEvent> = _uiEvent
 
     private val _alarms = mutableStateListOf<AlarmItemState>()

--- a/app/src/main/java/com/ruuvi/station/tagsettings/ui/BackgroundViewModel.kt
+++ b/app/src/main/java/com/ruuvi/station/tagsettings/ui/BackgroundViewModel.kt
@@ -21,7 +21,7 @@ class BackgroundViewModel(
 
     lateinit var cameraFile: Pair<File, Uri>
 
-    private val _uiEvent = MutableSharedFlow<UiEvent> (1)
+    private val _uiEvent = MutableSharedFlow<UiEvent> (0,1)
     val uiEvent: SharedFlow<UiEvent> = _uiEvent
 
     fun getDefaultImages(): List<Int> = tagSettingsInteractor.getDefaultImages()

--- a/app/src/main/java/com/ruuvi/station/tagsettings/ui/TagSettingsViewModel.kt
+++ b/app/src/main/java/com/ruuvi/station/tagsettings/ui/TagSettingsViewModel.kt
@@ -42,7 +42,7 @@ class TagSettingsViewModel(
 ) : ViewModel() {
     var file: Uri? = null
 
-    private val _uiEvent = MutableSharedFlow<UiEvent> (1)
+    private val _uiEvent = MutableSharedFlow<UiEvent> (0,1)
     val uiEvent: SharedFlow<UiEvent> = _uiEvent
 
     private val _sensorState = MutableStateFlow<RuuviTag>(requireNotNull(interactor.getFavouriteSensorById(sensorId)))


### PR DESCRIPTION
Events related to settings page has been set to (0.1), ensuring the event is delivered to the UI as soon as it's ready, but without replaying it later.