### PR TITLE
Improve alphabetical ordering to support natural number sorting

### DIFF
--- a/app/src/main/java/com/ruuvi/station/database/domain/TagRepository.kt
+++ b/app/src/main/java/com/ruuvi/station/database/domain/TagRepository.kt
@@ -8,7 +8,6 @@ import com.ruuvi.station.tag.domain.RuuviTag
 import com.ruuvi.station.tag.domain.TagConverter
 import com.ruuvi.station.util.AlphabetNumberComparator
 import timber.log.Timber
-import java.text.Collator
 import java.util.*
 
 class TagRepository(

--- a/app/src/main/java/com/ruuvi/station/database/domain/TagRepository.kt
+++ b/app/src/main/java/com/ruuvi/station/database/domain/TagRepository.kt
@@ -6,9 +6,10 @@ import com.raizlabs.android.dbflow.sql.language.SQLite
 import com.ruuvi.station.database.tables.*
 import com.ruuvi.station.tag.domain.RuuviTag
 import com.ruuvi.station.tag.domain.TagConverter
+import com.ruuvi.station.util.AlphabetNumberComparator
 import timber.log.Timber
-import java.util.*
 import java.text.Collator
+import java.util.*
 
 class TagRepository(
     private val sensorSettingsRepository: SensorSettingsRepository,
@@ -56,7 +57,7 @@ class TagRepository(
             .on(SensorSettings_Table.id.withTable().eq(RuuviTagEntity_Table.id.withTable()))
             .queryCustomList(FavouriteSensorQuery::class.java)
             .map { tagConverter.fromDatabase(it) }
-            .sortedWith( compareBy(Collator.getInstance()) {it.displayName} )
+            .sortedWith( compareBy(AlphabetNumberComparator()) {it.displayName} )
     }
 
     fun getFavoriteSensorById(id: String): RuuviTag? {

--- a/app/src/main/java/com/ruuvi/station/util/AlphabetNumberComparator.kt
+++ b/app/src/main/java/com/ruuvi/station/util/AlphabetNumberComparator.kt
@@ -1,0 +1,69 @@
+package com.ruuvi.station.util
+
+import java.text.Collator
+import java.util.Comparator
+
+class AlphabetNumberComparator : Comparator<String?> {
+    private val collator = Collator.getInstance()
+
+    private fun isDigit(ch: Char) = ch.isDigit()
+
+    private fun getChunk(s: String, slen: Int, marker: Int): String {
+        var currentMarker = marker
+        val chunk = StringBuilder()
+        var c = s[currentMarker]
+        chunk.append(c)
+        currentMarker++
+        if (isDigit(c)) {
+            while (currentMarker < slen) {
+                c = s[currentMarker]
+                if (!isDigit(c)) break
+                chunk.append(c)
+                currentMarker++
+            }
+        } else {
+            while (currentMarker < slen) {
+                c = s[currentMarker]
+                if (isDigit(c)) break
+                chunk.append(c)
+                currentMarker++
+            }
+        }
+        return chunk.toString()
+    }
+
+    override fun compare(s1: String?, s2: String?): Int {
+        if (s1 == null && s2 == null) return 0
+        if (s1 == null) return -1
+        if (s2 == null) return 1
+
+        var thisMarker = 0
+        var thatMarker = 0
+        val s1Length = s1.length
+        val s2Length = s2.length
+
+        while (thisMarker < s1Length && thatMarker < s2Length) {
+            val thisChunk = getChunk(s1, s1Length, thisMarker)
+            thisMarker += thisChunk.length
+            val thatChunk = getChunk(s2, s2Length, thatMarker)
+            thatMarker += thatChunk.length
+
+            var result: Int
+            if (isDigit(thisChunk[0]) && isDigit(thatChunk[0])) {
+                try {
+                    val thisValue = thisChunk.toLong()
+                    val thatValue = thatChunk.toLong()
+                    result = thisValue.compareTo(thatValue)
+                } catch (_: NumberFormatException) {
+                    result = thisChunk.compareTo(thatChunk)
+                }
+            } else {
+                result = collator.compare(thisChunk, thatChunk)
+            }
+
+            if (result != 0) return result
+        }
+
+        return s1Length - s2Length
+    }
+}


### PR DESCRIPTION
- Implement AlphabetNumberComparator to enable natural sorting of sensor names (e.g., 1, 2, 10 instead of 1, 10, 2).
- Update TagRepository to use AlphabetNumberComparator when fetching favorite sensors.