### PR TITLE
Fix Sonar path definitions, exclude dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,16 +37,29 @@ plugins {
     id 'jacoco'
 }
 
-sonarqube {
+sonar {
     properties {
         property "sonar.projectKey", "ruuvi_com.ruuvi.station"
         property "sonar.organization", "ruuvi"
         property "sonar.host.url", "https://sonarcloud.io"
-        property "sonar.sources", "app/src/main/java"
-        property "sonar.tests", "app/src/test/java"
-        property "sonar.java.coveragePlugin", "jacoco"
-        property "sonar.coverage.jacoco.xmlReportPaths", "${project.projectDir}/app/build/reports/jacoco/jacocoTestReport/jacocoTestReport.xml"
-        property "sonar.junit.reportPaths", "${project.projectDir}/app/build/test-results/testWithoutFileLogsDebugUnitTest"
+    }
+}
+
+project(":app") {
+    sonar {
+        properties {
+            property "sonar.sources", "src/main/java"
+            property "sonar.tests", "src/test/java"
+            property "sonar.java.coveragePlugin", "jacoco"
+            property "sonar.coverage.jacoco.xmlReportPaths", "${project.buildDir}/reports/jacoco/jacocoTestReport/jacocoTestReport.xml"
+            property "sonar.junit.reportPaths", "${project.buildDir}/test-results/testWithoutFileLogsDebugUnitTest"
+        }
+    }
+}
+
+[project(":default_bluetooth_library"), project(":MPChartLib")].each { moduleProject ->
+    moduleProject.sonar {
+        skipProject = true
     }
 }
 


### PR DESCRIPTION
Closes #1574

Important: This still uses Jacoco as the reports source and is broken for coverage analysis. Not fixing that part since #1561 has move to Mockito scheduled 