### PR TITLE
1603 Abs.humidity and Dew point alert triggering when not supposed to Trigger

### DIFF
--- a/app/src/main/java/com/ruuvi/station/alarm/domain/AlarmCheckInteractor.kt
+++ b/app/src/main/java/com/ruuvi/station/alarm/domain/AlarmCheckInteractor.kt
@@ -168,14 +168,16 @@ class AlarmCheckInteractor(
                     }
                     AlarmType.AQI -> {
                         val displayThreshold = unitsConverter.getDisplayValue(thresholdValue.toFloat())
-                        context.getString(resource, "$displayThreshold")
+                        context.getString(resource, displayThreshold)
                     }
                     AlarmType.ABSOLUTE_HUMIDITY -> {
                         val displayThreshold = unitsConverter.getDisplayValue(thresholdValue.toFloat())
                         context.getString(resource, "$displayThreshold ${context.getString(R.string.humidity_absolute_unit)}")
                     }
                     AlarmType.DEW_POINT -> {
-                        val displayThreshold = unitsConverter.getDisplayValue(thresholdValue.toFloat())
+                        val displayThreshold = unitsConverter.getDisplayValue(
+                            unitsConverter.getTemperatureValue(thresholdValue).toFloat()
+                        )
                         context.getString(resource, "$displayThreshold ${unitsConverter.getTemperatureUnitString()}")
                     }
                     AlarmType.BATTERY_VOLTAGE -> {

--- a/app/src/main/java/com/ruuvi/station/tag/domain/TagConverter.kt
+++ b/app/src/main/java/com/ruuvi/station/tag/domain/TagConverter.kt
@@ -43,7 +43,7 @@ class TagConverter(
             description = sensorSettings.description,
             valuesToDisplay = listOf(),
             latestMeasurement = SensorMeasurements(
-                aqi = unitsConverter.getAqiEnviromentValue(AQI.getAQI(
+                aqi = unitsConverter.getAqiEnvironmentValue(AQI.getAQI(
                     pm25 = entity.pm25,
                     co2 = entity.co2)
                 ),
@@ -178,7 +178,7 @@ class TagConverter(
                 }
                 AirQuality.AqiIndex -> {
                     valuesToDisplay.add(
-                        unitsConverter.getAqiEnviromentValue(AQI.getAQI(
+                        unitsConverter.getAqiEnvironmentValue(AQI.getAQI(
                             pm25 = entity.pm25,
                             co2 = entity.co2)
                         )
@@ -266,7 +266,7 @@ class TagConverter(
             valuesToDisplay = valuesToDisplay,
             latestMeasurement = entity.latestId?.let {
                 SensorMeasurements(
-                    aqi = unitsConverter.getAqiEnviromentValue(AQI.getAQI(
+                    aqi = unitsConverter.getAqiEnvironmentValue(AQI.getAQI(
                         pm25 = entity.pm25,
                         co2 = entity.co2)
                     ),

--- a/app/src/main/java/com/ruuvi/station/tag/domain/TagConverter.kt
+++ b/app/src/main/java/com/ruuvi/station/tag/domain/TagConverter.kt
@@ -51,8 +51,9 @@ class TagConverter(
                 pressure = pressure?.let { unitsConverter.getPressureEnvironmentValue(it) },
                 humidity = humidity?.let {
                     unitsConverter.getHumidityEnvironmentValue(
-                        it,
-                        temperature
+                        humidity = it,
+                        temperature = temperature,
+                        humidityUnit = HumidityUnit.Relative
                     )
                 },
                 absoluteHumidity = humidity?.let {
@@ -277,7 +278,11 @@ class TagConverter(
                         unitsConverter.getPressureEnvironmentValue(it)
                     },
                     humidity = humidity?.let {
-                        unitsConverter.getHumidityEnvironmentValue(it, temperature)
+                        unitsConverter.getHumidityEnvironmentValue(
+                            humidity = it,
+                            temperature = temperature,
+                            humidityUnit = HumidityUnit.Relative
+                        )
                     },
                     absoluteHumidity = humidity?.let {
                         unitsConverter.getHumidityEnvironmentValue(

--- a/app/src/main/java/com/ruuvi/station/tagdetails/ui/SensorCardViewModel.kt
+++ b/app/src/main/java/com/ruuvi/station/tagdetails/ui/SensorCardViewModel.kt
@@ -297,9 +297,15 @@ class SensorCardViewModel(
                             }
                             is HumidityUnit.Relative -> alarms.firstOrNull { it.alarmType == AlarmType.HUMIDITY }
                                 ?.let { it.min to it.max }
+                            is HumidityUnit.Absolute -> alarms.firstOrNull { it.alarmType == AlarmType.ABSOLUTE_HUMIDITY }
+                                ?.let { it.min to it.max }
+                            is HumidityUnit.DewPoint -> alarms.firstOrNull { it.alarmType == AlarmType.DEW_POINT }
+                                ?.let {
+                                    unitsConverter.getTemperatureValue(it.min) to unitsConverter.getTemperatureValue(it.max)
+                                }
                             is PressureUnit -> alarms.firstOrNull { it.alarmType == AlarmType.PRESSURE }
                                 ?.let {
-                                    unitsConverter.getPressureValue(it.min) to unitsConverter.getPressureValue(it.max)
+                                    unitsConverter.getPressureValue(it.min, unit) to unitsConverter.getPressureValue(it.max, unit)
                                 }
                             is CO2 -> alarms.firstOrNull { it.alarmType == AlarmType.CO2 }
                                 ?.let { it.min to it.max }
@@ -318,6 +324,12 @@ class SensorCardViewModel(
                             is Luminosity -> alarms.firstOrNull { it.alarmType == AlarmType.LUMINOSITY }
                                 ?.let { it.min to it.max }
                             is SoundAvg -> alarms.firstOrNull { it.alarmType == AlarmType.SOUND }
+                                ?.let { it.min to it.max }
+                            is SignalStrengthUnit -> alarms.firstOrNull { it.alarmType == AlarmType.RSSI }
+                                ?.let { it.min to it.max }
+                            is AirQuality -> alarms.firstOrNull { it.alarmType == AlarmType.AQI }
+                                ?.let { it.min to it.max }
+                            is BatteryVoltageUnit -> alarms.firstOrNull { it.alarmType == AlarmType.BATTERY_VOLTAGE }
                                 ?.let { it.min to it.max }
                             else -> null
                         }

--- a/app/src/main/java/com/ruuvi/station/units/domain/UnitsConverter.kt
+++ b/app/src/main/java/com/ruuvi/station/units/domain/UnitsConverter.kt
@@ -35,14 +35,14 @@ class UnitsConverter (
     }
 
     // AQI
-    fun getAqiEnviromentValue(
+    fun getAqiEnvironmentValue(
         value: AQI
     ): EnvironmentValue {
         if (value.score != null) {
-            val aqi = getValueWithoutUnit(value.score.toDouble(), Accuracy.Accuracy0)
+            val aqi = getValueWithoutUnit(value.score, Accuracy.Accuracy0)
             return EnvironmentValue(
-                original = value.score.toDouble(),
-                value = value.score.toDouble(),
+                original = value.score,
+                value = value.score,
                 accuracy = Accuracy.Accuracy0,
                 valueWithUnit = "$aqi/100 ${context.getString(AirQuality.AqiIndex.unit)}",
                 valueWithoutUnit = "$aqi/100",
@@ -250,18 +250,19 @@ class UnitsConverter (
         temperature: Double?,
         humidityUnit: HumidityUnit = getHumidityUnit(),
         accuracy: Accuracy = getHumidityAccuracy()
-    ): EnvironmentValue? =
-        getHumidityValue(humidity, temperature, humidityUnit)?.let {
-            EnvironmentValue (
-                original = humidity,
-                value = it,
-                accuracy = accuracy,
-                valueWithUnit = getHumidityString(humidity, temperature, humidityUnit),
-                valueWithoutUnit = getHumidityStringWithoutUnit(humidity, temperature, humidityUnit),
-                unitString = getHumidityUnitString(humidityUnit),
-                unitType = humidityUnit
-            )
-        }
+    ): EnvironmentValue? {
+        val value = getHumidityValue(humidity, temperature, humidityUnit) ?: return null
+        val original = getHumidityOriginalValue(humidity, temperature, humidityUnit) ?: return null
+        return EnvironmentValue(
+            original = original,
+            value = value,
+            accuracy = accuracy,
+            valueWithUnit = getHumidityString(humidity, temperature, humidityUnit),
+            valueWithoutUnit = getHumidityStringWithoutUnit(humidity, temperature, humidityUnit),
+            unitString = getHumidityUnitString(humidityUnit),
+            unitType = humidityUnit
+        )
+    }
 
 
     fun getHumidityUnit(): HumidityUnit = preferences.getHumidityUnit()
@@ -291,7 +292,7 @@ class UnitsConverter (
 
         return when (humidityUnit) {
             HumidityUnit.Relative -> humidity.round(2)
-            HumidityUnit.Absolute-> converter?.let { it.absoluteHumidity.round(2) }
+            HumidityUnit.Absolute-> converter?.absoluteHumidity?.round(2)
             HumidityUnit.DewPoint -> {
                 converter?.let {
                     when (getTemperatureUnit()) {
@@ -301,6 +302,28 @@ class UnitsConverter (
                     }
                 }
             }
+        }
+    }
+
+    private fun getHumidityOriginalValue(
+        humidity: Double,
+        temperature: Double?,
+        humidityUnit: HumidityUnit
+    ): Double? {
+        if (humidityUnit == HumidityUnit.Relative) {
+            return humidity.round(2)
+        }
+        val converter = temperature?.let {
+            if (it !in -100.0..370.0) {
+                null
+            } else {
+                HumidityConverter(temperature, humidity / 100)
+            }
+        } ?: return null
+        return when (humidityUnit) {
+            HumidityUnit.Relative -> humidity.round(2)
+            HumidityUnit.Absolute -> converter.absoluteHumidity.round(2)
+            HumidityUnit.DewPoint -> converter.toDewCelsius?.round(2)
         }
     }
 
@@ -368,10 +391,10 @@ class UnitsConverter (
     }
 
     fun getDisplayValue(value: Float): String {
-        if (value.isInteger(0.009f)) {
-            return getDisplayApproximateValue(value)
+        return if (value.isInteger(0.009f)) {
+            getDisplayApproximateValue(value)
         } else {
-            return getDisplayPreciseValue(value)
+            getDisplayPreciseValue(value)
         }
     }
     fun getDisplayPreciseValue(value: Float): String {

--- a/app/src/main/java/com/ruuvi/station/units/model/UnitType.kt
+++ b/app/src/main/java/com/ruuvi/station/units/model/UnitType.kt
@@ -70,6 +70,7 @@ sealed class UnitType(
         unit: Int,
         measurementTitle: Int,
         measurementName: Int,
+        alarmType: AlarmType = AlarmType.HUMIDITY
     ): UnitType(
         unitCode = code,
         unitTitle = unitTitle,
@@ -78,7 +79,7 @@ sealed class UnitType(
         measurementTitle = measurementTitle,
         measurementName = measurementName,
         iconRes = R.drawable.icon_humidity,
-        alarmType = AlarmType.HUMIDITY,
+        alarmType = alarmType,
         defaultAccuracy = Accuracy.Accuracy2
     ) {
         data object Relative: HumidityUnit(
@@ -86,21 +87,24 @@ sealed class UnitType(
             unitTitle = R.string.humidity_relative_name,
             unit = R.string.humidity_relative_unit,
             measurementTitle = R.string.relative_humidity,
-            measurementName = R.string.rel_humidity
+            measurementName = R.string.rel_humidity,
+            alarmType = AlarmType.HUMIDITY
         )
         data object Absolute: HumidityUnit(
             code = HUMIDITY_ABSOLUTE_CODE,
             unitTitle = R.string.humidity_absolute_name,
             unit = R.string.humidity_absolute_unit,
             measurementTitle = R.string.absolute_humidity,
-            measurementName = R.string.abs_humidity
+            measurementName = R.string.abs_humidity,
+            alarmType = AlarmType.ABSOLUTE_HUMIDITY
         )
         data object DewPoint: HumidityUnit(
             code = HUMIDITY_DEW_POINT_CODE,
             unitTitle = R.string.humidity_dew_point_name,
             unit = R.string.humidity_dew_point_unit,
             measurementTitle = R.string.dewpoint,
-            measurementName = R.string.dewpoint
+            measurementName = R.string.dewpoint,
+            alarmType = AlarmType.DEW_POINT
         )
 
         companion object {


### PR DESCRIPTION


Absolute humidity alerts were evaluated against RH% because EnvironmentValue.original for humidity always used raw relative humidity. Now original is computed per humidity mode:
- Relative: RH%
- Absolute: computed g/m³
- Dew point: computed °C (storage/comparison unit)

This aligns alarm comparisons with saved thresholds and prevents false absolute-humidity triggers when values are actually within range.

Also rename getAqiEnviromentValue -> getAqiEnvironmentValue and update call sites.