### PR TITLE
Fix: Drag and drop measurement ordering is broken in visible measurements #1620

### DIFF
--- a/app/src/main/java/com/ruuvi/station/tagsettings/ui/ItemListDragAndDropState.kt
+++ b/app/src/main/java/com/ruuvi/station/tagsettings/ui/ItemListDragAndDropState.kt
@@ -75,7 +75,7 @@ class ItemListDragAndDropState(
     private var currentIndexOfDraggedItem by mutableStateOf(-1)
     private var overscrollJob by mutableStateOf<Job?>(null)
 
-    var isDragInProgress: Boolean = false
+    var isDragInProgress by mutableStateOf(false)
 
     // Retrieve the currently dragged element's info
     private val currentElement: LazyListItemInfo?
@@ -102,15 +102,20 @@ class ItemListDragAndDropState(
             ?.also {
                 currentIndexOfDraggedItem = it.index
                 initiallyDraggedElement = it
+                isDragInProgress = true
             }
     }
 
     // Handle interrupted drag gesture
     fun onDragInterrupted() {
+        if (isDragInProgress) {
+            onDoneDragging.invoke()
+        }
         draggedDistance = 0f
         currentIndexOfDraggedItem = -1
         initiallyDraggedElement = null
         overscrollJob?.cancel()
+        isDragInProgress = false
     }
 
 

--- a/app/src/main/java/com/ruuvi/station/tagsettings/ui/visible_measurements/VisibleMeasurements.kt
+++ b/app/src/main/java/com/ruuvi/station/tagsettings/ui/visible_measurements/VisibleMeasurements.kt
@@ -234,7 +234,10 @@ fun VisibleMeasurements(
                 selected = selected,
                 allOptions = allOptions,
                 onMove = { from, to ->
-                    onAction(VisibleMeasurementsActions.SwapDisplayOrderItems(from, to))
+                    onAction(VisibleMeasurementsActions.MoveDisplayOrderItem(from, to))
+                },
+                onDoneDragging = {
+                    onAction(VisibleMeasurementsActions.OnDoneDragging)
                 },
                 onAdd = { listOption ->
                     onAction(VisibleMeasurementsActions.AddToDisplayOrder(listOption.unit))
@@ -253,13 +256,14 @@ fun DragAndDropListEdit(
     selected: List<ListOption>,
     allOptions: List<ListOption>,
     onMove: (Int, Int) -> Unit,
+    onDoneDragging: () -> Unit,
     onAdd: (ListOption) -> Unit,
     onRemove: (ListOption) -> Unit,
     modifier: Modifier = Modifier
 ) {
     val dragDropListState = rememberDragDropListState (
         onMove = onMove,
-        onDoneDragging = { }
+        onDoneDragging = onDoneDragging
     )
 
     val itemHeight = 48.dp * LocalDensity.current.fontScale

--- a/app/src/main/java/com/ruuvi/station/tagsettings/ui/visible_measurements/VisibleMeasurementsActions.kt
+++ b/app/src/main/java/com/ruuvi/station/tagsettings/ui/visible_measurements/VisibleMeasurementsActions.kt
@@ -7,7 +7,8 @@ sealed interface VisibleMeasurementsActions {
     data class AddToDisplayOrder(val unit: UnitType): VisibleMeasurementsActions
     data class RemoveFromDisplayOrder(val unit: UnitType): VisibleMeasurementsActions
     data class RemoveFromDisplayOrderAndDisableAlert(val unit: UnitType): VisibleMeasurementsActions
-    data class SwapDisplayOrderItems(val from: Int, val to: Int): VisibleMeasurementsActions
+    data class MoveDisplayOrderItem(val from: Int, val to: Int): VisibleMeasurementsActions
+    object OnDoneDragging: VisibleMeasurementsActions
     data class ChangeUseDefaultAndDisableAlert(val useDefault: Boolean, val units: List<UnitType>): VisibleMeasurementsActions
 }
 

--- a/app/src/main/java/com/ruuvi/station/tagsettings/ui/visible_measurements/VisibleMeasurementsViewModel.kt
+++ b/app/src/main/java/com/ruuvi/station/tagsettings/ui/visible_measurements/VisibleMeasurementsViewModel.kt
@@ -54,7 +54,15 @@ class VisibleMeasurementsViewModel(
                 true
             )
 
-    private val _selected = MutableStateFlow<List<ListOption>>(listOf())
+    private val _selected = MutableStateFlow(
+        _sensorState.value.displayOrder.map { unitType ->
+            ListOption(
+                id = unitType.getCode(),
+                title = getUnitName(unitType),
+                unit = unitType,
+            )
+        }
+    )
     val selected: StateFlow<List<ListOption>> = _selected
 
     val possibleOptions: StateFlow<List<ListOption>> =
@@ -219,8 +227,12 @@ class VisibleMeasurementsViewModel(
 
     private fun onDoneDragging() {
         val displayOrder = _selected.value.map { it.id }
-        saveDisplayOrder(displayOrder)
+        val currentOrder = _sensorState.value.displayOrder.map { it.getCode() }
+        if (displayOrder != currentOrder) {
+            saveDisplayOrder(displayOrder)
+        }
     }
+
 
     private fun saveDisplayOrder(displayOrder: List<String>) {
         interactor.newDisplayOrder(sensorId, Gson().toJson(displayOrder))

--- a/app/src/main/java/com/ruuvi/station/tagsettings/ui/visible_measurements/VisibleMeasurementsViewModel.kt
+++ b/app/src/main/java/com/ruuvi/station/tagsettings/ui/visible_measurements/VisibleMeasurementsViewModel.kt
@@ -7,7 +7,7 @@ import com.ruuvi.station.alarm.domain.AlarmItemState
 import com.ruuvi.station.alarm.domain.AlarmType
 import com.ruuvi.station.alarm.domain.AlarmsInteractor
 import com.ruuvi.station.app.preferences.PreferencesRepository
-import com.ruuvi.station.dashboard.ui.swap
+import com.ruuvi.station.tagsettings.ui.move
 import com.ruuvi.station.database.domain.SensorSettingsRepository
 import com.ruuvi.station.tag.domain.RuuviTag
 import com.ruuvi.station.tag.domain.VisibleMeasurementsOrderInteractor
@@ -54,23 +54,8 @@ class VisibleMeasurementsViewModel(
                 true
             )
 
-    val selected: StateFlow<List<ListOption>> =
-        _sensorState
-            .mapNotNull {
-                it.displayOrder.mapNotNull { unitType ->
-                    Timber.d("selected $unitType")
-                    ListOption(
-                        id = unitType.getCode(),
-                        title = getUnitName(unitType),
-                        unit = unitType,
-                    )
-                }
-            }
-            .stateIn(
-                viewModelScope,
-                SharingStarted.WhileSubscribed(1000),
-                listOf()
-            )
+    private val _selected = MutableStateFlow<List<ListOption>>(listOf())
+    val selected: StateFlow<List<ListOption>> = _selected
 
     val possibleOptions: StateFlow<List<ListOption>> =
         _sensorState
@@ -94,6 +79,20 @@ class VisibleMeasurementsViewModel(
     private val _effects = MutableSharedFlow<VisibleMeasurementsEffect>(extraBufferCapacity = 1)
     val effects = _effects.asSharedFlow()
 
+    init {
+        viewModelScope.launch {
+            _sensorState.collect { ruuviTag ->
+                _selected.value = ruuviTag.displayOrder.map { unitType ->
+                    ListOption(
+                        id = unitType.getCode(),
+                        title = getUnitName(unitType),
+                        unit = unitType,
+                    )
+                }
+            }
+        }
+    }
+
     fun onAction(action: VisibleMeasurementsActions) {
         when (action) {
             is VisibleMeasurementsActions.ChangeUseDefault ->
@@ -105,8 +104,11 @@ class VisibleMeasurementsViewModel(
             is VisibleMeasurementsActions.RemoveFromDisplayOrder ->
                 removeFromDisplayOrder(action.unit)
 
-            is VisibleMeasurementsActions.SwapDisplayOrderItems ->
-                swapDisplayOrderItems(action.from, action.to)
+            is VisibleMeasurementsActions.MoveDisplayOrderItem ->
+                moveDisplayOrderItem(action.from, action.to)
+
+            is VisibleMeasurementsActions.OnDoneDragging ->
+                onDoneDragging()
 
             is VisibleMeasurementsActions.RemoveFromDisplayOrderAndDisableAlert -> {
                 disableAlertAndRemove(action.unit)
@@ -124,11 +126,10 @@ class VisibleMeasurementsViewModel(
 
     private fun addToDisplayOrder(unit: UnitType) {
         val displayOrder = selected.value
-            .mapNotNull { it.id }
+            .map { it.id }
             .toMutableList()
         displayOrder.add(unit.getCode())
-        interactor.newDisplayOrder(sensorId, Gson().toJson(displayOrder))
-        _sensorState.update { requireNotNull(interactor.getFavouriteSensorById(sensorId)) }
+        saveDisplayOrder(displayOrder)
     }
 
     private fun removeFromDisplayOrder(unit: UnitType) {
@@ -202,21 +203,27 @@ class VisibleMeasurementsViewModel(
 
     private fun actualDelete(unit: UnitType) {
         val displayOrder = selected.value
-            .mapNotNull { it.id }
+            .map { it.id }
             .toMutableList()
         if (displayOrder.size > 1) {
             displayOrder.remove(unit.getCode())
-            interactor.newDisplayOrder(sensorId, Gson().toJson(displayOrder))
-            _sensorState.update { requireNotNull(interactor.getFavouriteSensorById(sensorId)) }
+            saveDisplayOrder(displayOrder)
         }
     }
 
-    private fun swapDisplayOrderItems(from: Int, to: Int) {
-        val displayOrder = selected.value
-            .mapNotNull { it.id }
-            .toMutableList()
-        val swapped = displayOrder.swap(from, to)
-        interactor.newDisplayOrder(sensorId, Gson().toJson(swapped))
+    private fun moveDisplayOrderItem(from: Int, to: Int) {
+        val currentList = _selected.value.toMutableList()
+        currentList.move(from, to)
+        _selected.value = currentList
+    }
+
+    private fun onDoneDragging() {
+        val displayOrder = _selected.value.map { it.id }
+        saveDisplayOrder(displayOrder)
+    }
+
+    private fun saveDisplayOrder(displayOrder: List<String>) {
+        interactor.newDisplayOrder(sensorId, Gson().toJson(displayOrder))
         _sensorState.update { requireNotNull(interactor.getFavouriteSensorById(sensorId)) }
     }
 


### PR DESCRIPTION
Drag and drop measurement sequence number to new ordering in the visible measurements list, but seems I can only move one step at a time.